### PR TITLE
fix: Skip TPM installation on Windows

### DIFF
--- a/run_onchange_install_tpm.sh.tmpl
+++ b/run_onchange_install_tpm.sh.tmpl
@@ -1,6 +1,7 @@
+{{ if ne .chezmoi.os "windows" -}}
 #!/usr/bin/env bash
 
-# Install TPM
+# Install TPM (skipped on Windows - tmux/tpm not supported)
 TPM_PATH="${HOME}/.tmux/plugins/tpm"
 "$CHEZMOI_SOURCE_DIR/bin/figprint" "Installing TPM..."
 if [ -d "${TPM_PATH}" ]; then
@@ -8,6 +9,6 @@ if [ -d "${TPM_PATH}" ]; then
 	cd $TPM_PATH
 	git pull
 else
-	git clone https://github.com/tmux-plugins/tpm "${tpm_path}"
+	git clone https://github.com/tmux-plugins/tpm "${TPM_PATH}"
 fi
-
+{{ end -}}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR fixes the exception thrown when running `chezmoi init --apply` on Windows/PowerShell.

## Problem

When initializing chezmoi on Windows, the `run_onchange_install_tpm.sh.tmpl` script was executed unconditionally, resulting in:

```
chezmoi: install_tpm.sh: fork/exec C:\Users\nickl\AppData\Local\Temp\701405404.install_tpm.sh: %1 is not a valid Win32 application.
```

This happens because tmux and TPM (Tmux Plugin Manager) are not available on Windows, and Windows cannot execute bash scripts directly.

## Solution

Wrapped the script content in a chezmoi template conditional that checks the operating system:

```go-template
{{ if ne .chezmoi.os "windows" -}}
...script content...
{{ end -}}
```

This follows the same pattern already used by `run_onchange_darwin-install-packages.sh.tmpl` and `run_onchange_linux-install-packages.sh.tmpl`, which guard their execution based on the target OS.

## Additional Fix

Also fixed a variable name bug in the original script: the `else` branch used `"${tpm_path}"` (lowercase) but the variable is defined as `TPM_PATH` (uppercase). This would have caused the git clone to fail on fresh installations.

## Testing

- On Windows: The script will be skipped entirely (empty output from template)
- On macOS/Linux: The script functions exactly as before
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a37c5d6-c05f-4ef6-b2ba-a83d23b0c8a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a37c5d6-c05f-4ef6-b2ba-a83d23b0c8a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

