### PR TITLE
feat: Add PowerShell prompt customization with Oh-My-Posh

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -7,6 +7,26 @@ packages:
     - 'typescript'
     - 'typescript-language-server'
     - 'graphql-language-service-cli'
+  windows:
+    winget:
+      - 'JanDeDobbeleer.OhMyPosh'
+      - 'Git.Git'
+      - 'Microsoft.WindowsTerminal'
+      - 'Microsoft.PowerShell'
+      - 'Neovim.Neovim'
+      - 'sharkdp.fd'
+      - 'BurntSushi.ripgrep.MSVC'
+      - 'sharkdp.bat'
+      - 'eza-community.eza'
+      - 'ajeetdsouza.zoxide'
+      - 'junegunn.fzf'
+      - 'stedolan.jq'
+    pwsh_modules:
+      - 'PSReadLine'
+      - 'Terminal-Icons'
+      - 'PSFzf'
+    fonts:
+      - 'NerdFonts.UbuntuMono'
   linux:
     # TODO: Implement snap & x-window packages (maybe get them to work with WSL?)
     # snap:

--- a/dot_config/powershell/Microsoft.PowerShell_profile.ps1
+++ b/dot_config/powershell/Microsoft.PowerShell_profile.ps1
@@ -1,0 +1,190 @@
+# PowerShell Profile Configuration
+# Managed by chezmoi - https://www.chezmoi.io/
+# This file is sourced by PowerShell on startup when placed at:
+#   Windows: $HOME\Documents\PowerShell\Microsoft.PowerShell_profile.ps1
+#   Cross-platform: $HOME\.config\powershell\Microsoft.PowerShell_profile.ps1
+
+# ============================================================================
+# Oh-My-Posh Prompt Configuration
+# ============================================================================
+
+# Theme path - uses the bundled p10k_rainbow theme for consistency with Zsh setup
+$OMP_THEME = "$HOME\.config\powershell\themes\p10k_rainbow.omp.json"
+
+# Initialize Oh-My-Posh with the custom theme
+if (Get-Command oh-my-posh -ErrorAction SilentlyContinue) {
+    if (Test-Path $OMP_THEME) {
+        oh-my-posh init pwsh --config $OMP_THEME | Invoke-Expression
+    } else {
+        # Fallback to built-in powerlevel10k_rainbow theme if custom theme not found
+        oh-my-posh init pwsh --config powerlevel10k_rainbow | Invoke-Expression
+    }
+} else {
+    Write-Warning "Oh-My-Posh is not installed. Install it with: winget install JanDeDobbeleer.OhMyPosh"
+}
+
+# ============================================================================
+# PSReadLine Configuration - Enhanced command line editing
+# ============================================================================
+
+if (Get-Module -ListAvailable -Name PSReadLine) {
+    # Set vi mode for those who prefer it (uncomment to enable)
+    # Set-PSReadLineOption -EditMode Vi
+
+    # History settings
+    Set-PSReadLineOption -HistorySearchCursorMovesToEnd
+    Set-PSReadLineOption -PredictionSource History
+    Set-PSReadLineOption -PredictionViewStyle ListView
+    Set-PSReadLineOption -MaximumHistoryCount 10000
+
+    # Key bindings for history search
+    Set-PSReadLineKeyHandler -Key UpArrow -Function HistorySearchBackward
+    Set-PSReadLineKeyHandler -Key DownArrow -Function HistorySearchForward
+    Set-PSReadLineKeyHandler -Key Tab -Function MenuComplete
+
+    # Ctrl+r for reverse history search (similar to bash/zsh)
+    Set-PSReadLineKeyHandler -Key Ctrl+r -Function ReverseSearchHistory
+    Set-PSReadLineKeyHandler -Key Ctrl+s -Function ForwardSearchHistory
+}
+
+# ============================================================================
+# Terminal Icons - File icons in directory listings
+# ============================================================================
+
+if (Get-Module -ListAvailable -Name Terminal-Icons) {
+    Import-Module -Name Terminal-Icons
+}
+
+# ============================================================================
+# Zoxide - Smarter directory navigation (like z/autojump)
+# ============================================================================
+
+if (Get-Command zoxide -ErrorAction SilentlyContinue) {
+    Invoke-Expression (& { (zoxide init powershell | Out-String) })
+}
+
+# ============================================================================
+# FZF - Fuzzy finder integration
+# ============================================================================
+
+if (Get-Module -ListAvailable -Name PSFzf) {
+    Import-Module PSFzf
+    Set-PsFzfOption -PSReadlineChordProvider 'Ctrl+t' -PSReadlineChordReverseHistory 'Ctrl+r'
+}
+
+# ============================================================================
+# Useful Aliases
+# ============================================================================
+
+# Git shortcuts
+Set-Alias -Name g -Value git
+function gst { git status }
+function gco { git checkout $args }
+function gcm { git commit -m $args }
+function gp { git push }
+function gl { git pull }
+function gd { git diff $args }
+function ga { git add $args }
+function gaa { git add --all }
+function gb { git branch $args }
+function glog { git log --oneline --graph --decorate -20 }
+
+# Navigation
+function .. { Set-Location .. }
+function ... { Set-Location ..\.. }
+function .... { Set-Location ..\..\.. }
+
+# Better ls alternatives (if eza/exa is installed)
+if (Get-Command eza -ErrorAction SilentlyContinue) {
+    function ll { eza -la --icons $args }
+    function la { eza -a --icons $args }
+    function lt { eza -T --icons $args }
+    function l { eza --icons $args }
+} elseif (Get-Command exa -ErrorAction SilentlyContinue) {
+    function ll { exa -la --icons $args }
+    function la { exa -a --icons $args }
+    function lt { exa -T --icons $args }
+    function l { exa --icons $args }
+} else {
+    function ll { Get-ChildItem -Force $args }
+    function la { Get-ChildItem -Force $args }
+}
+
+# Create directory and navigate into it
+function mkcd {
+    param([string]$Path)
+    New-Item -ItemType Directory -Path $Path -Force | Out-Null
+    Set-Location $Path
+}
+
+# ============================================================================
+# Environment Configuration
+# ============================================================================
+
+# Add common paths to PATH if they exist
+$additionalPaths = @(
+    "$HOME\.local\bin",
+    "$HOME\bin",
+    "$HOME\scoop\shims",
+    "$env:LOCALAPPDATA\Programs\oh-my-posh\bin"
+)
+
+foreach ($path in $additionalPaths) {
+    if (Test-Path $path) {
+        $env:PATH = "$path;$env:PATH"
+    }
+}
+
+# Default editor
+if (Get-Command nvim -ErrorAction SilentlyContinue) {
+    $env:EDITOR = "nvim"
+    $env:VISUAL = "nvim"
+} elseif (Get-Command vim -ErrorAction SilentlyContinue) {
+    $env:EDITOR = "vim"
+    $env:VISUAL = "vim"
+} elseif (Get-Command code -ErrorAction SilentlyContinue) {
+    $env:EDITOR = "code --wait"
+    $env:VISUAL = "code --wait"
+}
+
+# ============================================================================
+# Custom Functions
+# ============================================================================
+
+# Quick file search (requires fd or falls back to Get-ChildItem)
+function ff {
+    param([string]$Pattern)
+    if (Get-Command fd -ErrorAction SilentlyContinue) {
+        fd $Pattern
+    } else {
+        Get-ChildItem -Recurse -Filter "*$Pattern*" | Select-Object FullName
+    }
+}
+
+# Quick grep (requires ripgrep or falls back to Select-String)
+function rg {
+    param([string]$Pattern, [string]$Path = ".")
+    if (Get-Command rg.exe -ErrorAction SilentlyContinue) {
+        & rg.exe $Pattern $Path
+    } else {
+        Get-ChildItem -Recurse -Path $Path -File | Select-String -Pattern $Pattern
+    }
+}
+
+# Which command (similar to Unix which)
+function which {
+    param([string]$Command)
+    Get-Command $Command -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Definition
+}
+
+# Reload profile
+function Reload-Profile {
+    . $PROFILE
+    Write-Host "Profile reloaded!" -ForegroundColor Green
+}
+
+# ============================================================================
+# Startup Message (Optional - comment out if not wanted)
+# ============================================================================
+
+# Write-Host "PowerShell $($PSVersionTable.PSVersion) - Profile loaded" -ForegroundColor Cyan

--- a/dot_config/powershell/README.md
+++ b/dot_config/powershell/README.md
@@ -1,0 +1,109 @@
+# PowerShell Configuration
+
+This directory contains PowerShell configuration managed by chezmoi, providing a customized prompt experience similar to the Zsh + Powerlevel10k setup.
+
+## Features
+
+- **Oh-My-Posh prompt** - Colorful, informative prompt matching the Powerlevel10k rainbow theme
+- **Git integration** - Branch name, status indicators, and helpful aliases
+- **PSReadLine enhancements** - History search, tab completion, prediction
+- **Zoxide integration** - Smart directory navigation
+- **Terminal Icons** - File icons in directory listings
+- **FZF integration** - Fuzzy file and history search
+
+## Requirements
+
+Install the following using `winget` (or chezmoi will install them automatically):
+
+```powershell
+winget install JanDeDobbeleer.OhMyPosh
+winget install Microsoft.WindowsTerminal
+winget install ajeetdsouza.zoxide
+winget install junegunn.fzf
+```
+
+Install PowerShell modules:
+
+```powershell
+Install-Module -Name PSReadLine -Scope CurrentUser -Force
+Install-Module -Name Terminal-Icons -Scope CurrentUser -Force
+Install-Module -Name PSFzf -Scope CurrentUser -Force
+```
+
+### Nerd Font
+
+For the icons and symbols to display correctly, install a Nerd Font:
+
+```powershell
+winget install NerdFonts.UbuntuMono
+```
+
+Then configure Windows Terminal to use "UbuntuMono Nerd Font" or similar.
+
+## File Structure
+
+```
+dot_config/powershell/
+├── Microsoft.PowerShell_profile.ps1  # Main profile (sourced on startup)
+├── themes/
+│   └── p10k_rainbow.omp.json         # Oh-My-Posh theme
+└── README.md                          # This file
+```
+
+## Chezmoi Mapping
+
+After `chezmoi apply`, these files will be placed at:
+
+- `~/.config/powershell/Microsoft.PowerShell_profile.ps1`
+- `~/.config/powershell/themes/p10k_rainbow.omp.json`
+
+## Linking to PowerShell
+
+PowerShell looks for profiles at `$PROFILE`. To use this config, either:
+
+**Option 1: Symlink (Recommended)**
+```powershell
+$profileDir = Split-Path $PROFILE -Parent
+New-Item -ItemType SymbolicLink -Path $PROFILE -Target "$HOME\.config\powershell\Microsoft.PowerShell_profile.ps1" -Force
+```
+
+**Option 2: Source from default profile**
+Add this to your `$PROFILE`:
+```powershell
+. "$HOME\.config\powershell\Microsoft.PowerShell_profile.ps1"
+```
+
+## Customization
+
+### Change Theme
+
+Edit `themes/p10k_rainbow.omp.json` or switch to a built-in theme:
+
+```powershell
+# In Microsoft.PowerShell_profile.ps1, change:
+$OMP_THEME = "$HOME\.config\powershell\themes\p10k_rainbow.omp.json"
+# To use a built-in theme:
+# oh-my-posh init pwsh --config paradox | Invoke-Expression
+```
+
+### Theme Preview
+
+Preview Oh-My-Posh themes:
+
+```powershell
+Get-PoshThemes
+```
+
+## Aliases Included
+
+| Alias | Command |
+|-------|---------|
+| `g` | `git` |
+| `gst` | `git status` |
+| `gco` | `git checkout` |
+| `gcm` | `git commit -m` |
+| `gp` | `git push` |
+| `gl` | `git pull` |
+| `ll` | `eza -la --icons` (or `Get-ChildItem -Force`) |
+| `..` | `cd ..` |
+| `mkcd` | Create directory and cd into it |

--- a/dot_config/powershell/themes/p10k_rainbow.omp.json
+++ b/dot_config/powershell/themes/p10k_rainbow.omp.json
@@ -1,0 +1,269 @@
+{
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+  "version": 4,
+  "final_space": true,
+  "console_title_template": "{{ .Shell }} in {{ .Folder }}",
+  "blocks": [
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "segments": [
+        {
+          "type": "os",
+          "style": "diamond",
+          "leading_diamond": "\u256d\u2500\ue0b2",
+          "foreground": "#000000",
+          "background": "#d3d7cf",
+          "template": " {{ if .WSL }}WSL at {{ end }}{{.Icon}} "
+        },
+        {
+          "type": "path",
+          "style": "powerline",
+          "powerline_symbol": "\ue0b0",
+          "foreground": "#e4e4e4",
+          "background": "#3465a4",
+          "template": " \uf07c {{ .Path }} ",
+          "properties": {
+            "home_icon": "~",
+            "style": "full"
+          }
+        },
+        {
+          "type": "git",
+          "style": "powerline",
+          "powerline_symbol": "\ue0b0",
+          "foreground": "#000000",
+          "background": "#4e9a06",
+          "background_templates": [
+            "{{ if or (.Working.Changed) (.Staging.Changed) }}#c4a000{{ end }}",
+            "{{ if and (gt .Ahead 0) (gt .Behind 0) }}#f26d50{{ end }}",
+            "{{ if gt .Ahead 0 }}#89d1dc{{ end }}",
+            "{{ if gt .Behind 0 }}#4e9a06{{ end }}"
+          ],
+          "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }} ",
+          "properties": {
+            "branch_icon": "\uf126 ",
+            "fetch_status": true,
+            "fetch_upstream_icon": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "prompt",
+      "alignment": "right",
+      "segments": [
+        {
+          "type": "node",
+          "style": "powerline",
+          "powerline_symbol": "\ue0b2",
+          "invert_powerline": true,
+          "foreground": "#ffffff",
+          "background": "#689f63",
+          "template": " {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} \ue718 ",
+          "properties": {
+            "fetch_version": true
+          }
+        },
+        {
+          "type": "dotnet",
+          "style": "powerline",
+          "powerline_symbol": "\ue0b2",
+          "invert_powerline": true,
+          "foreground": "#ffffff",
+          "background": "#512bd4",
+          "template": " {{ if .Unsupported }}\uf071{{ else }}{{ .Full }}{{ end }} \ue77f ",
+          "properties": {
+            "fetch_version": true
+          }
+        },
+        {
+          "type": "go",
+          "style": "powerline",
+          "powerline_symbol": "\ue0b2",
+          "invert_powerline": true,
+          "foreground": "#111111",
+          "background": "#00acd7",
+          "template": " {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} \ue627 ",
+          "properties": {
+            "fetch_version": true
+          }
+        },
+        {
+          "type": "python",
+          "style": "powerline",
+          "powerline_symbol": "\ue0b2",
+          "invert_powerline": true,
+          "foreground": "#111111",
+          "background": "#FFDE57",
+          "template": " {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} \ue235 ",
+          "properties": {
+            "display_mode": "files",
+            "fetch_virtual_env": true
+          }
+        },
+        {
+          "type": "java",
+          "style": "powerline",
+          "powerline_symbol": "\ue0b2",
+          "invert_powerline": true,
+          "foreground": "#ffffff",
+          "background": "#5382a1",
+          "template": " {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} \ue738 ",
+          "properties": {
+            "fetch_version": true
+          }
+        },
+        {
+          "type": "ruby",
+          "style": "powerline",
+          "powerline_symbol": "\ue0b2",
+          "invert_powerline": true,
+          "foreground": "#ffffff",
+          "background": "#AE1401",
+          "template": " {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} \ue791 ",
+          "properties": {
+            "display_mode": "files",
+            "fetch_version": true
+          }
+        },
+        {
+          "type": "rust",
+          "style": "powerline",
+          "powerline_symbol": "\ue0b2",
+          "invert_powerline": true,
+          "foreground": "#ffffff",
+          "background": "#f74c00",
+          "template": " {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} \ue7a8 ",
+          "properties": {
+            "fetch_version": true
+          }
+        },
+        {
+          "type": "kubectl",
+          "style": "powerline",
+          "powerline_symbol": "\ue0b2",
+          "invert_powerline": true,
+          "foreground": "#ffffff",
+          "background": "#326ce5",
+          "template": " {{ .Context }}{{ if .Namespace }} :: {{ .Namespace }}{{ end }} \ufd31 ",
+          "properties": {
+            "display_error": false
+          }
+        },
+        {
+          "type": "aws",
+          "style": "powerline",
+          "powerline_symbol": "\ue0b2",
+          "invert_powerline": true,
+          "foreground": "#ffffff",
+          "background": "#FFA400",
+          "background_templates": [
+            "{{if contains \"default\" .Profile}}#FFA400{{end}}",
+            "{{if contains \"prod\" .Profile}}#f1184c{{end}}"
+          ],
+          "template": " {{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }} \ue7ad ",
+          "properties": {
+            "display_default": false
+          }
+        },
+        {
+          "type": "azure",
+          "style": "powerline",
+          "powerline_symbol": "\ue0b2",
+          "invert_powerline": true,
+          "foreground": "#ffffff",
+          "background": "#0078d4",
+          "template": " {{ .Name }} \uebd8 ",
+          "properties": {
+            "display_default": false
+          }
+        },
+        {
+          "type": "root",
+          "style": "powerline",
+          "powerline_symbol": "\ue0b2",
+          "invert_powerline": true,
+          "foreground": "#111111",
+          "background": "#ffff66",
+          "template": " \uf0ad "
+        },
+        {
+          "type": "executiontime",
+          "style": "powerline",
+          "powerline_symbol": "\ue0b2",
+          "invert_powerline": true,
+          "foreground": "#000000",
+          "background": "#c4a000",
+          "template": " {{ .FormattedMs }} \uf252 ",
+          "properties": {
+            "threshold": 500
+          }
+        },
+        {
+          "type": "status",
+          "style": "powerline",
+          "powerline_symbol": "\ue0b2",
+          "invert_powerline": true,
+          "foreground": "#d3d7cf",
+          "background": "#000000",
+          "background_templates": [
+            "{{ if gt .Code 0 }}#cc2222{{ end }}"
+          ],
+          "template": " {{ if gt .Code 0 }}{{ reason .Code }}{{ else }}\uf42e{{ end }} ",
+          "properties": {
+            "always_enabled": true
+          }
+        },
+        {
+          "type": "time",
+          "style": "diamond",
+          "trailing_diamond": "\ue0b0\u2500\u256e",
+          "invert_powerline": true,
+          "foreground": "#000000",
+          "background": "#d3d7cf",
+          "template": " {{ .CurrentDate | date .Format }} \uf017 ",
+          "properties": {
+            "time_format": "3:04 PM"
+          }
+        }
+      ]
+    },
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "newline": true,
+      "segments": [
+        {
+          "type": "text",
+          "style": "plain",
+          "foreground": "#d3d7cf",
+          "template": "\u2570\u2500"
+        },
+        {
+          "type": "status",
+          "style": "plain",
+          "foreground": "#4e9a06",
+          "foreground_templates": [
+            "{{ if gt .Code 0 }}#cc2222{{ end }}"
+          ],
+          "template": "{{ if gt .Code 0 }}\uf00d{{ else }}\uf054{{ end }} ",
+          "properties": {
+            "always_enabled": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "rprompt",
+      "segments": [
+        {
+          "type": "text",
+          "style": "plain",
+          "foreground": "#d3d7cf",
+          "template": "\u2500\u256f"
+        }
+      ]
+    }
+  ]
+}

--- a/run_onchange_windows-install-packages.ps1.tmpl
+++ b/run_onchange_windows-install-packages.ps1.tmpl
@@ -1,0 +1,58 @@
+{{ if eq .chezmoi.os "windows" -}}
+# Windows Package Installation Script
+# Managed by chezmoi - runs when package list changes
+
+Write-Host "`n========================================" -ForegroundColor Cyan
+Write-Host "Installing Windows packages via winget" -ForegroundColor Cyan  
+Write-Host "========================================`n" -ForegroundColor Cyan
+
+# Install winget packages
+$wingetPackages = @(
+{{ range .packages.windows.winget -}}
+    {{ . | quote }}
+{{ end -}}
+)
+
+foreach ($package in $wingetPackages) {
+    if ($package) {
+        Write-Host "Installing $package..." -ForegroundColor Yellow
+        winget install --id $package --accept-source-agreements --accept-package-agreements -e
+    }
+}
+
+Write-Host "`n========================================" -ForegroundColor Cyan
+Write-Host "Installing PowerShell modules" -ForegroundColor Cyan
+Write-Host "========================================`n" -ForegroundColor Cyan
+
+# Install PowerShell modules
+$psModules = @(
+{{ range .packages.windows.pwsh_modules -}}
+    {{ . | quote }}
+{{ end -}}
+)
+
+foreach ($module in $psModules) {
+    if ($module) {
+        Write-Host "Installing module: $module..." -ForegroundColor Yellow
+        if (-not (Get-Module -ListAvailable -Name $module)) {
+            Install-Module -Name $module -Scope CurrentUser -Force -AllowClobber
+        } else {
+            Write-Host "Module $module is already installed" -ForegroundColor Green
+        }
+    }
+}
+
+Write-Host "`n========================================" -ForegroundColor Green
+Write-Host "Package installation complete!" -ForegroundColor Green
+Write-Host "========================================`n" -ForegroundColor Green
+
+# Setup PowerShell profile if it doesn't exist
+$profileDir = Split-Path $PROFILE -Parent
+if (-not (Test-Path $profileDir)) {
+    New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
+    Write-Host "Created PowerShell profile directory: $profileDir" -ForegroundColor Yellow
+}
+
+# Note: chezmoi will manage the actual profile content
+Write-Host "`nNote: Run 'chezmoi apply' to setup your PowerShell profile" -ForegroundColor Cyan
+{{ end -}}

--- a/todo.md
+++ b/todo.md
@@ -41,6 +41,9 @@
 - [ ] Create a head & headless version
 
 ## Windows Support:
-- [ ] Create windows specific version of `./run_onchange_darwin-install-packages.sh.tmpl`
+- [x] Create windows specific version of `./run_onchange_darwin-install-packages.sh.tmpl`
+- [x] Setup PowerShell prompt with Oh-My-Posh (matching Powerlevel10k rainbow theme)
+- [x] Add PowerShell profile configuration
+- [x] Add Windows package list to `.chezmoidata/packages.yaml`
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR adds PowerShell prompt customization using Oh-My-Posh, providing a similar experience to the existing Zsh + Powerlevel10k setup.

## Changes

### New Files

- **`dot_config/powershell/Microsoft.PowerShell_profile.ps1`** - PowerShell profile with:
  - Oh-My-Posh prompt initialization
  - PSReadLine configuration for enhanced command line editing
  - Terminal-Icons integration for file icons
  - Zoxide integration for smart directory navigation
  - FZF fuzzy finder support
  - Git aliases and navigation shortcuts

- **`dot_config/powershell/themes/p10k_rainbow.omp.json`** - Custom Oh-My-Posh theme matching the Powerlevel10k rainbow style from the Zsh setup:
  - Two-line prompt with powerline separators
  - Git status with branch name and change indicators
  - Language version segments (Node, .NET, Python, Java, Go, etc.)
  - Kubernetes context, AWS/Azure cloud context
  - Execution time and status indicators

- **`run_onchange_windows-install-packages.ps1.tmpl`** - Chezmoi run_onchange script for Windows that:
  - Installs packages via winget
  - Installs PowerShell modules

- **`dot_config/powershell/README.md`** - Documentation for setup and customization

### Updated Files

- **`.chezmoidata/packages.yaml`** - Added Windows package list:
  - winget packages: Oh-My-Posh, Git, Windows Terminal, neovim, fd, ripgrep, bat, eza, zoxide, fzf, jq
  - PowerShell modules: PSReadLine, Terminal-Icons, PSFzf
  - Fonts: Ubuntu Mono Nerd Font

- **`todo.md`** - Marked Windows support tasks as complete

## Setup Instructions

After running `chezmoi apply` on Windows:

1. Install a Nerd Font (Ubuntu Mono Nerd Font recommended)
2. Configure Windows Terminal to use the Nerd Font
3. Link the profile to PowerShell's expected location:

```powershell
# Option 1: Symlink
New-Item -ItemType SymbolicLink -Path $PROFILE -Target "$HOME\.config\powershell\Microsoft.PowerShell_profile.ps1" -Force

# Option 2: Source from default profile
Add-Content $PROFILE '. "$HOME\.config\powershell\Microsoft.PowerShell_profile.ps1"'
```

## Screenshots

The prompt will look similar to the existing Powerlevel10k rainbow theme - colorful powerline-style with git integration, language versions on the right side, and a two-line layout.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85d790e2-cf27-4e59-87f9-a12dce82ef11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85d790e2-cf27-4e59-87f9-a12dce82ef11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

