### PR TITLE
Feature: Add better Java Development support to neovim configs

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -53,6 +53,8 @@ packages:
       - 'zoxide'
       - 'wget'
       - 'neovim'
+      # Eclipse JDT Language Server for Java development in Neovim
+      - 'jdtls'
       # JVM tools now managed via SDKMAN (see packages.sdkman section)
       # - 'maven'        # Moved to sdkman
       # - 'apache-flink' # Can be installed via sdkman if needed

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply git@github.com:NickLediet/d
 
 This will:
 1. Clone the repository
-2. Apply configurations to your home directory
-3. Set up all dotfiles in their correct locations
+2. Install SDKMAN (if not already installed)
+3. Install Java, Maven, and Spring Boot CLI via SDKMAN
+4. Apply configurations to your home directory
+5. Set up all dotfiles in their correct locations
 
 ## What's Included
 
@@ -70,33 +72,46 @@ dotties/
 │   └── dot_lil-dotties/        # Additional shell configs
 ├── dot_zshrc                   # Zsh configuration
 ├── dot_p10k.zsh                # Powerlevel10k config
-├── .chezmoidata/               # Chezmoi data files
-│   └── packages.yaml           # Package definitions
-└── run_onchange_*.sh.tmpl      # Install scripts
+├── .chezmoidata/
+│   └── packages.yaml           # Package & SDK definitions
+├── run_onchange_before_install-sdkman.sh.tmpl    # SDKMAN installer
+├── run_onchange_after_install-sdkman-sdks.sh.tmpl # SDK installer (Java, Maven, etc.)
+└── run_onchange_*.sh.tmpl      # Other install scripts
 ```
 
 ## Java Development Setup
 
-This dotfiles repo is optimized for Java development with SDKMAN for managing multiple JDK versions.
+This dotfiles repo uses [SDKMAN](https://sdkman.io/) for managing Java, Maven, and other JVM tools. **SDKMAN is installed automatically** when you apply the dotfiles with chezmoi.
 
-### Install SDKMAN
+### What Gets Installed Automatically
+
+The following are installed via SDKMAN when you run `chezmoi apply`:
+
+| Tool | Versions | Notes |
+|------|----------|-------|
+| Java (Temurin) | 21 (default), 17, 11 | LTS versions |
+| Maven | 3.9.6 | Latest stable |
+| Spring Boot CLI | 3.2.5 | For Spring development |
+
+See `.chezmoidata/packages.yaml` to customize versions.
+
+### Managing Java Versions
 
 ```bash
-curl -s "https://get.sdkman.io" | bash
-source "$HOME/.sdkman/bin/sdkman-init.sh"
-```
+# List installed versions
+sdk current
 
-### Install a JDK
+# Switch Java version for current session
+sdk use java 17.0.11-tem
 
-```bash
-# List available JDKs
+# Set default Java version
+sdk default java 21.0.3-tem
+
+# List all available Java distributions
 sdk list java
 
-# Install Temurin JDK 21 (recommended)
-sdk install java 21.0.2-tem
-
-# Set as default
-sdk default java 21.0.2-tem
+# Install additional versions
+sdk install java 22.0.1-tem
 ```
 
 ### Why SDKMAN over Homebrew?
@@ -105,6 +120,7 @@ sdk default java 21.0.2-tem
 - **Consistent paths**: Standard paths that work well with build tools and IDEs
 - **Cross-platform**: Works the same on macOS and Linux
 - **Build tool integration**: Works seamlessly with Maven, Gradle, etc.
+- **No path conflicts**: Avoids the pathing issues that occur with Homebrew-installed JDKs
 
 The Neovim Java configuration automatically detects SDKMAN-managed JDKs at `~/.sdkman/candidates/java/current/`.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,201 @@
-## Installation
+# Dotfiles
 
-Before running the installation command, please first [install chezmoi](https://www.chezmoi.io/install/#__tabbed_1_1).
+Personal dotfiles managed with [chezmoi](https://www.chezmoi.io/), featuring a modern development environment with Neovim (NvChad), tmux, and zsh configurations.
 
-Then you can run this ez-pz one-liner:
-```sh
+## Quick Start
+
+### Prerequisites
+
+- [chezmoi](https://www.chezmoi.io/install/) installed on your system
+- Git configured with SSH access to GitHub
+
+### Installation
+
+```bash
 sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply git@github.com:NickLediet/dotties.git
 ```
+
+This will:
+1. Clone the repository
+2. Apply configurations to your home directory
+3. Set up all dotfiles in their correct locations
+
+## What's Included
+
+### Neovim Configuration
+
+A fully-featured Neovim setup built on [NvChad](https://nvchad.com/) v2.5 with:
+
+- **Java Development** - Full LSP support via nvim-jdtls
+  - Code completion, navigation, and refactoring
+  - JUnit test runner integration
+  - Debugging with nvim-dap
+  - Lombok support
+  - SDKMAN-managed JDK support
+- **Web Development** - HTML, CSS, TypeScript LSP
+- **Treesitter** - Modern syntax highlighting
+- **Formatting** - Conform.nvim with Google Java Format, Stylua
+- **File Navigation** - Telescope, nvim-tree
+- **Git Integration** - gitsigns, fugitive
+
+See [nvim/README.md](dot_config/nvim/README.md) for detailed configuration documentation.
+
+### Tmux Configuration
+
+Tmux setup with:
+- Custom keybindings
+- Theme configuration
+- TPM (Tmux Plugin Manager) integration
+- Session management
+
+### Zsh Configuration
+
+Zsh setup featuring:
+- [Powerlevel10k](https://github.com/romkatv/powerlevel10k) prompt
+- Custom aliases
+- Development tool integrations (Java, Node, etc.)
+
+## Directory Structure
+
+```
+dotties/
+├── dot_config/
+│   ├── nvim/                   # Neovim/NvChad configuration
+│   │   ├── init.lua
+│   │   ├── lua/
+│   │   │   ├── plugins/        # Plugin specifications
+│   │   │   └── configs/        # Plugin configurations
+│   │   └── ftplugin/           # Filetype-specific configs
+│   ├── tmux/                   # Tmux configuration
+│   └── dot_lil-dotties/        # Additional shell configs
+├── dot_zshrc                   # Zsh configuration
+├── dot_p10k.zsh                # Powerlevel10k config
+├── .chezmoidata/               # Chezmoi data files
+│   └── packages.yaml           # Package definitions
+└── run_onchange_*.sh.tmpl      # Install scripts
+```
+
+## Java Development Setup
+
+This dotfiles repo is optimized for Java development with SDKMAN for managing multiple JDK versions.
+
+### Install SDKMAN
+
+```bash
+curl -s "https://get.sdkman.io" | bash
+source "$HOME/.sdkman/bin/sdkman-init.sh"
+```
+
+### Install a JDK
+
+```bash
+# List available JDKs
+sdk list java
+
+# Install Temurin JDK 21 (recommended)
+sdk install java 21.0.2-tem
+
+# Set as default
+sdk default java 21.0.2-tem
+```
+
+### Why SDKMAN over Homebrew?
+
+- **Multiple versions**: Easily manage and switch between JDK versions
+- **Consistent paths**: Standard paths that work well with build tools and IDEs
+- **Cross-platform**: Works the same on macOS and Linux
+- **Build tool integration**: Works seamlessly with Maven, Gradle, etc.
+
+The Neovim Java configuration automatically detects SDKMAN-managed JDKs at `~/.sdkman/candidates/java/current/`.
+
+## Post-Installation
+
+After applying dotfiles, run these additional setup steps:
+
+### 1. Install Neovim Plugins
+
+Open Neovim - plugins will auto-install via Lazy.nvim.
+
+### 2. Install Mason Tools
+
+In Neovim, run:
+```vim
+:MasonInstall jdtls java-debug-adapter java-test google-java-format lemminx stylua
+```
+
+### 3. Install Treesitter Parsers
+
+In Neovim, run:
+```vim
+:TSInstall all
+```
+
+### 4. Install Tmux Plugins
+
+Press `<prefix> + I` in tmux to install TPM plugins.
+
+## Platform Support
+
+| Platform | Status |
+|----------|--------|
+| macOS | ✅ Primary |
+| Linux/WSL | 🚧 In progress |
+| Windows | 🚧 Planned |
+
+## Updating
+
+Pull latest changes and reapply:
+
+```bash
+chezmoi update
+```
+
+Or manually:
+
+```bash
+chezmoi git pull
+chezmoi apply
+```
+
+## Customization
+
+### Local Overrides
+
+Chezmoi supports local customization via:
+- `~/.config/chezmoi/chezmoi.toml` - Local configuration
+- Template variables in `.chezmoidata/`
+
+### Adding New Configurations
+
+1. Add the file to your home directory
+2. Run `chezmoi add <file>` to track it
+3. Commit and push changes
+
+## Troubleshooting
+
+### Neovim Issues
+
+See [nvim/README.md](dot_config/nvim/README.md#troubleshooting-java-lsp) for Neovim-specific troubleshooting.
+
+### Chezmoi Issues
+
+```bash
+# View what would change
+chezmoi diff
+
+# Apply with verbose output
+chezmoi apply -v
+
+# Re-initialize if needed
+chezmoi init --apply git@github.com:NickLediet/dotties.git
+```
+
+## Contributing
+
+This is a personal dotfiles repository, but feel free to:
+- Open issues for bugs or suggestions
+- Fork for your own customization
+
+## License
+
+MIT License - See [LICENSE](LICENSE) for details.

--- a/dot_config/nvim/README.md
+++ b/dot_config/nvim/README.md
@@ -25,27 +25,44 @@ This is a custom Neovim configuration built on [NvChad](https://nvchad.com/) v2.
 - **Java 17+** - Required for JDTLS (Java Language Server)
 - **Maven** or **Gradle** - For project dependency management
 
-#### Recommended: SDKMAN for Java Management
+#### SDKMAN Integration (Automatic)
 
-This configuration is optimized for [SDKMAN](https://sdkman.io/) which allows easy management of multiple JDK versions:
+This dotfiles repository uses [SDKMAN](https://sdkman.io/) for managing Java, Maven, and other JVM tools. **SDKMAN and JDKs are installed automatically** when you apply the dotfiles with chezmoi.
+
+The automatic installation includes:
+- **Java** - Temurin 21 (default), 17, and 11
+- **Maven** - Latest stable version
+- **Spring Boot CLI** - For Spring development
+
+See `.chezmoidata/packages.yaml` for the configured versions.
+
+##### Manual SDKMAN Commands
+
+If you need to manage Java versions manually:
 
 ```bash
-# Install SDKMAN
-curl -s "https://get.sdkman.io" | bash
+# List available Java versions
+sdk list java
 
-# Install a JDK (Java 17+)
-sdk install java 21.0.2-tem
+# Install a specific version
+sdk install java 21.0.3-tem
 
-# Set default JDK
-sdk default java 21.0.2-tem
+# Switch Java version for current session
+sdk use java 17.0.11-tem
+
+# Set default Java version
+sdk default java 21.0.3-tem
+
+# Check current versions
+sdk current
 ```
 
-The configuration automatically detects SDKMAN-managed Java installations at:
-- `~/.sdkman/candidates/java/current/bin/java`
+##### How Neovim Finds Java
 
-Alternative Java sources are also supported:
-- `$JAVA_HOME/bin/java`
-- System `java` command
+The Neovim Java configuration automatically detects Java in this priority order:
+1. `~/.sdkman/candidates/java/current/bin/java` (SDKMAN - preferred)
+2. `$JAVA_HOME/bin/java` (environment variable)
+3. System `java` command (fallback)
 
 ## Installation
 

--- a/dot_config/nvim/README.md
+++ b/dot_config/nvim/README.md
@@ -1,9 +1,232 @@
-**This repo is supposed to be used as config by NvChad users!**
+# NvChad Configuration
 
-- The main nvchad repo (NvChad/NvChad) is used as a plugin by this repo.
-- So you just import its modules , like `require "nvchad.options" , require "nvchad.mappings"`
-- So you can delete the .git from this repo ( when you clone it locally ) or fork it :)
+This is a custom Neovim configuration built on [NvChad](https://nvchad.com/) v2.5, providing a modern IDE-like experience with full Java development support.
 
-# Credits
+## Features
 
-1) Lazyvim starter https://github.com/LazyVim/starter as nvchad's starter was inspired by Lazyvim's . It made a lot of things easier!
+- **NvChad v2.5** - Modern Neovim configuration framework
+- **Java Development** - Full LSP support via nvim-jdtls with debugging capabilities
+- **Treesitter** - Syntax highlighting for Java, Lua, TypeScript, and more
+- **LSP Support** - HTML, CSS, TypeScript, XML (lemminx), and Java (jdtls)
+- **Formatting** - Conform.nvim with Google Java Format, Stylua, and more
+- **Debugging** - DAP integration for Java debugging
+
+## Prerequisites
+
+### General Requirements
+
+- **Neovim** >= 0.10.0
+- **Git**
+- **Node.js** (for some LSP servers)
+- A [Nerd Font](https://www.nerdfonts.com/) installed and configured in your terminal
+
+### Java Development Requirements
+
+- **Java 17+** - Required for JDTLS (Java Language Server)
+- **Maven** or **Gradle** - For project dependency management
+
+#### Recommended: SDKMAN for Java Management
+
+This configuration is optimized for [SDKMAN](https://sdkman.io/) which allows easy management of multiple JDK versions:
+
+```bash
+# Install SDKMAN
+curl -s "https://get.sdkman.io" | bash
+
+# Install a JDK (Java 17+)
+sdk install java 21.0.2-tem
+
+# Set default JDK
+sdk default java 21.0.2-tem
+```
+
+The configuration automatically detects SDKMAN-managed Java installations at:
+- `~/.sdkman/candidates/java/current/bin/java`
+
+Alternative Java sources are also supported:
+- `$JAVA_HOME/bin/java`
+- System `java` command
+
+## Installation
+
+After applying your dotfiles with chezmoi, the configuration will be available at `~/.config/nvim/`.
+
+### First-time Setup
+
+1. **Open Neovim** - Lazy.nvim will automatically install plugins
+2. **Install Mason tools** - Run `:Mason` and install required tools:
+   ```
+   :MasonInstall jdtls java-debug-adapter java-test google-java-format lemminx
+   ```
+   Or let Mason auto-install them (configured in `lua/plugins/java.lua`)
+
+3. **Sync Treesitter parsers** - Run `:TSInstall all` or restart Neovim
+
+## Directory Structure
+
+```
+nvim/
+├── init.lua                    # Bootstrap lazy.nvim and load NvChad
+├── lua/
+│   ├── chadrc.lua              # NvChad UI/theme configuration
+│   ├── options.lua             # Vim options (tabstop, etc.)
+│   ├── mappings.lua            # Custom keymaps
+│   ├── autocmds.lua            # Auto commands
+│   ├── configs/
+│   │   ├── lazy.lua            # Lazy.nvim configuration
+│   │   ├── lspconfig.lua       # LSP server configurations
+│   │   └── conform.lua         # Formatter configurations
+│   └── plugins/
+│       ├── init.lua            # Core plugin specs
+│       └── java.lua            # Java-specific plugins
+└── ftplugin/
+    └── java.lua                # Java filetype-specific config (JDTLS)
+```
+
+## Java Development
+
+### Features
+
+- **Code Completion** - Intelligent autocomplete with nvim-cmp
+- **Go to Definition/References** - Navigate Java code
+- **Organize Imports** - Automatic import management
+- **Code Actions** - Refactoring support (extract variable/method/constant)
+- **Debugging** - Debug Java applications with nvim-dap
+- **Test Running** - Run JUnit tests from Neovim
+- **Lombok Support** - Full Lombok annotation support
+
+### Java Keymaps
+
+All Java-specific keymaps use `<leader>j` prefix:
+
+| Keymap | Mode | Description |
+|--------|------|-------------|
+| `<leader>jo` | Normal | Organize imports |
+| `<leader>jv` | Normal/Visual | Extract variable |
+| `<leader>jc` | Normal/Visual | Extract constant |
+| `<leader>jm` | Visual | Extract method |
+| `<leader>jt` | Normal | Run test class |
+| `<leader>jn` | Normal | Run nearest test method |
+| `<leader>ju` | Normal | Update project configuration |
+| `<leader>jd` | Normal | Setup DAP main class configs |
+
+### Project Detection
+
+JDTLS automatically detects project roots by looking for:
+- `.git` directory
+- `pom.xml` (Maven)
+- `build.gradle` (Gradle)
+- `mvnw` / `gradlew` wrapper scripts
+
+### Workspace Data
+
+JDTLS workspace data is stored per-project at:
+```
+~/.local/share/nvim/jdtls-workspace/<project-name>/
+```
+
+### Troubleshooting Java LSP
+
+1. **Check if jdtls is installed:**
+   ```vim
+   :Mason
+   ```
+   Look for `jdtls` and ensure it shows as installed.
+
+2. **Check LSP status:**
+   ```vim
+   :LspInfo
+   ```
+
+3. **View LSP logs:**
+   ```vim
+   :lua vim.cmd('e ' .. vim.lsp.get_log_path())
+   ```
+
+4. **Verify Java version:**
+   ```bash
+   java -version  # Should be 17+
+   ```
+
+5. **Force JDTLS restart:**
+   ```vim
+   :JdtRestart
+   ```
+
+6. **Update project configuration:**
+   ```vim
+   :JdtUpdateConfig
+   ```
+
+## General Keymaps
+
+### Navigation
+| Keymap | Description |
+|--------|-------------|
+| `<leader>ff` | Find files |
+| `<leader>fw` | Live grep |
+| `<leader>fb` | Find buffers |
+| `<leader>e` | Toggle file tree |
+
+### LSP (all languages)
+| Keymap | Description |
+|--------|-------------|
+| `gd` | Go to definition |
+| `gr` | Go to references |
+| `K` | Hover documentation |
+| `<leader>ca` | Code actions |
+| `<leader>rn` | Rename symbol |
+
+### Other
+| Keymap | Description |
+|--------|-------------|
+| `;` | Command mode |
+| `jk` | Exit insert mode |
+| `<leader>th` | Change theme |
+
+## Formatting
+
+Formatting is handled by [conform.nvim](https://github.com/stevearc/conform.nvim).
+
+| Filetype | Formatter |
+|----------|-----------|
+| Lua | stylua |
+| Java | google-java-format (AOSP style) |
+| XML | lemminx |
+
+To format manually:
+```vim
+:lua require("conform").format()
+```
+
+To enable format on save, uncomment the `event = 'BufWritePre'` line in `lua/plugins/init.lua`.
+
+## Customization
+
+### Changing Theme
+
+Edit `lua/chadrc.lua`:
+```lua
+M.base46 = {
+  theme = "catppuccin", -- or any NvChad theme
+}
+```
+
+### Adding New LSP Servers
+
+1. Install via Mason: `:MasonInstall <server-name>`
+2. Add to `lua/configs/lspconfig.lua`:
+   ```lua
+   local servers = { "html", "cssls", "ts_ls", "lemminx", "your_server" }
+   ```
+
+### Adding Treesitter Parsers
+
+Edit `lua/plugins/init.lua` and add to the `ensure_installed` list.
+
+## Resources
+
+- [NvChad Documentation](https://nvchad.com/docs/quickstart/install)
+- [nvim-jdtls Wiki](https://github.com/mfussenegger/nvim-jdtls/wiki)
+- [SDKMAN Documentation](https://sdkman.io/usage)
+- [Lazy.nvim Documentation](https://lazy.folke.io/)

--- a/dot_config/nvim/README.md
+++ b/dot_config/nvim/README.md
@@ -70,14 +70,40 @@ After applying your dotfiles with chezmoi, the configuration will be available a
 
 ### First-time Setup
 
-1. **Open Neovim** - Lazy.nvim will automatically install plugins
-2. **Install Mason tools** - Run `:Mason` and install required tools:
-   ```
-   :MasonInstall jdtls java-debug-adapter java-test google-java-format lemminx
-   ```
-   Or let Mason auto-install them (configured in `lua/plugins/java.lua`)
+1. **Open Neovim** - Lazy.nvim will automatically install plugins (run `:Lazy sync` if needed)
 
-3. **Sync Treesitter parsers** - Run `:TSInstall all` or restart Neovim
+2. **Install JDTLS** (Eclipse Java Language Server) - Choose one method:
+
+   **Option A: Manual Install (Recommended)**
+   ```bash
+   mkdir -p ~/.local/share/jdtls
+   cd ~/.local/share/jdtls
+   curl -L -o jdtls.tar.gz https://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz
+   tar -xzf jdtls.tar.gz
+   rm jdtls.tar.gz
+   ```
+
+   **Option B: Homebrew (macOS)**
+   ```bash
+   brew install jdtls
+   ```
+
+   **Option C: Mason (may have issues)**
+   ```vim
+   :MasonInstall jdtls
+   ```
+
+3. **Install other Mason tools** (optional):
+   ```vim
+   :MasonInstall google-java-format lemminx
+   ```
+
+4. **Sync Treesitter parsers**:
+   ```vim
+   :TSInstall all
+   ```
+
+5. **Restart Neovim** and open a Java file to verify JDTLS starts
 
 ## Directory Structure
 
@@ -144,35 +170,66 @@ JDTLS workspace data is stored per-project at:
 
 ### Troubleshooting Java LSP
 
-1. **Check if jdtls is installed:**
-   ```vim
-   :Mason
+1. **Check if JDTLS is installed:**
+   ```bash
+   # Check manual install location
+   ls ~/.local/share/jdtls/plugins/org.eclipse.equinox.launcher_*.jar
+
+   # Or check Homebrew
+   ls /opt/homebrew/opt/jdtls/libexec/plugins/org.eclipse.equinox.launcher_*.jar
    ```
-   Look for `jdtls` and ensure it shows as installed.
 
 2. **Check LSP status:**
    ```vim
    :LspInfo
    ```
+   You should see `jdtls` listed as attached to the buffer.
 
-3. **View LSP logs:**
+3. **View JDTLS logs:**
+   ```vim
+   :JdtShowLogs
+   ```
+   Or check the LSP log:
    ```vim
    :lua vim.cmd('e ' .. vim.lsp.get_log_path())
    ```
 
-4. **Verify Java version:**
+4. **Verify Java version (must be 17+):**
    ```bash
-   java -version  # Should be 17+
+   java -version
+   # Or check SDKMAN
+   sdk current java
    ```
 
-5. **Force JDTLS restart:**
+5. **"JDTLS not found" error:**
+   Install JDTLS manually:
+   ```bash
+   mkdir -p ~/.local/share/jdtls && cd ~/.local/share/jdtls
+   curl -L -o jdtls.tar.gz https://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz
+   tar -xzf jdtls.tar.gz && rm jdtls.tar.gz
+   ```
+
+6. **Force JDTLS restart:**
    ```vim
    :JdtRestart
    ```
 
-6. **Update project configuration:**
+7. **Wipe corrupted workspace data:**
+   ```vim
+   :JdtWipeDataAndRestart
+   ```
+   Or manually delete: `~/.local/share/nvim/jdtls-workspace/<project-name>/`
+
+8. **Update project configuration:**
    ```vim
    :JdtUpdateConfig
+   ```
+
+9. **"Java XY language features not available":**
+   The config auto-detects SDKMAN-installed JDKs. Check that your project's Java version is installed:
+   ```bash
+   sdk list java
+   sdk install java 17.0.11-tem
    ```
 
 ## General Keymaps

--- a/dot_config/nvim/ftplugin/java.lua
+++ b/dot_config/nvim/ftplugin/java.lua
@@ -1,0 +1,289 @@
+-- Java-specific settings and JDTLS configuration
+-- This file is loaded automatically when opening Java files
+
+local jdtls_ok, jdtls = pcall(require, "jdtls")
+if not jdtls_ok then
+  vim.notify("nvim-jdtls not found, Java LSP will not be available", vim.log.levels.WARN)
+  return
+end
+
+-- Utility function to find the root directory of a Java project
+local function get_project_root()
+  return vim.fs.root(0, { ".git", "mvnw", "gradlew", "pom.xml", "build.gradle" }) or vim.fn.getcwd()
+end
+
+-- Get Mason registry for tool paths
+local mason_registry_ok, mason_registry = pcall(require, "mason-registry")
+if not mason_registry_ok then
+  vim.notify("Mason registry not found", vim.log.levels.WARN)
+  return
+end
+
+-- Wait for mason to be ready
+if not mason_registry.is_installed "jdtls" then
+  vim.notify("jdtls not installed via Mason. Run :MasonInstall jdtls", vim.log.levels.WARN)
+  return
+end
+
+-- Get paths from Mason
+local jdtls_pkg = mason_registry.get_package "jdtls"
+local jdtls_path = jdtls_pkg:get_install_path()
+
+-- Find the launcher jar
+local launcher_jar = vim.fn.glob(jdtls_path .. "/plugins/org.eclipse.equinox.launcher_*.jar")
+if launcher_jar == "" then
+  vim.notify("JDTLS launcher jar not found", vim.log.levels.ERROR)
+  return
+end
+
+-- Determine OS-specific config directory
+local os_config
+if vim.fn.has "mac" == 1 then
+  os_config = jdtls_path .. "/config_mac"
+elseif vim.fn.has "unix" == 1 then
+  os_config = jdtls_path .. "/config_linux"
+else
+  os_config = jdtls_path .. "/config_win"
+end
+
+-- Lombok support (bundled with Mason's jdtls)
+local lombok_jar = jdtls_path .. "/lombok.jar"
+local lombok_agent = ""
+if vim.fn.filereadable(lombok_jar) == 1 then
+  lombok_agent = "-javaagent:" .. lombok_jar
+end
+
+-- Workspace directory for JDTLS (per-project)
+local project_name = vim.fn.fnamemodify(get_project_root(), ":p:h:t")
+local workspace_dir = vim.fn.stdpath "data" .. "/jdtls-workspace/" .. project_name
+
+-- Find Java executable
+-- Supports SDKMAN, JAVA_HOME, or system java
+local function get_java_executable()
+  -- Check SDKMAN current java
+  local sdkman_java = vim.fn.expand "$HOME/.sdkman/candidates/java/current/bin/java"
+  if vim.fn.executable(sdkman_java) == 1 then
+    return sdkman_java
+  end
+
+  -- Check JAVA_HOME
+  local java_home = os.getenv "JAVA_HOME"
+  if java_home then
+    local java_from_home = java_home .. "/bin/java"
+    if vim.fn.executable(java_from_home) == 1 then
+      return java_from_home
+    end
+  end
+
+  -- Fallback to system java
+  if vim.fn.executable "java" == 1 then
+    return "java"
+  end
+
+  vim.notify("No Java executable found. Please install Java 17+ via SDKMAN or set JAVA_HOME", vim.log.levels.ERROR)
+  return nil
+end
+
+local java_cmd = get_java_executable()
+if not java_cmd then
+  return
+end
+
+-- Debug adapter paths (if installed)
+local bundles = {}
+
+-- Add java-debug-adapter
+if mason_registry.is_installed "java-debug-adapter" then
+  local java_debug_pkg = mason_registry.get_package "java-debug-adapter"
+  local java_debug_path = java_debug_pkg:get_install_path()
+  local debug_jar = vim.fn.glob(java_debug_path .. "/extension/server/com.microsoft.java.debug.plugin-*.jar", true)
+  if debug_jar ~= "" then
+    table.insert(bundles, debug_jar)
+  end
+end
+
+-- Add java-test
+if mason_registry.is_installed "java-test" then
+  local java_test_pkg = mason_registry.get_package "java-test"
+  local java_test_path = java_test_pkg:get_install_path()
+  local test_jars = vim.fn.glob(java_test_path .. "/extension/server/*.jar", true, true)
+  for _, jar in ipairs(test_jars) do
+    if not vim.endswith(jar, "com.microsoft.java.test.runner-jar-with-dependencies.jar") then
+      table.insert(bundles, jar)
+    end
+  end
+end
+
+-- Build the command to start JDTLS
+local cmd = {
+  java_cmd,
+  "-Declipse.application=org.eclipse.jdt.ls.core.id1",
+  "-Dosgi.bundles.defaultStartLevel=4",
+  "-Declipse.product=org.eclipse.jdt.ls.core.product",
+  "-Dlog.protocol=true",
+  "-Dlog.level=ALL",
+  "-Xms1g",
+  "-Xmx2G",
+  "--add-modules=ALL-SYSTEM",
+  "--add-opens",
+  "java.base/java.util=ALL-UNNAMED",
+  "--add-opens",
+  "java.base/java.lang=ALL-UNNAMED",
+}
+
+-- Add lombok agent if available
+if lombok_agent ~= "" then
+  table.insert(cmd, lombok_agent)
+end
+
+-- Add JVM arg to prevent metadata files in project root
+table.insert(cmd, "--jvm-arg=-Djava.import.generatesMetadataFilesAtProjectRoot=false")
+
+-- Add jar, config, and data arguments
+vim.list_extend(cmd, {
+  "-jar",
+  launcher_jar,
+  "-configuration",
+  os_config,
+  "-data",
+  workspace_dir,
+})
+
+-- Java-specific keymaps
+local function java_keymaps(bufnr)
+  local opts = { noremap = true, silent = true, buffer = bufnr }
+
+  -- JDTLS specific commands
+  vim.keymap.set("n", "<leader>jo", jdtls.organize_imports, vim.tbl_extend("force", opts, { desc = "[J]ava [O]rganize Imports" }))
+  vim.keymap.set("n", "<leader>jv", jdtls.extract_variable, vim.tbl_extend("force", opts, { desc = "[J]ava Extract [V]ariable" }))
+  vim.keymap.set("v", "<leader>jv", function() jdtls.extract_variable(true) end, vim.tbl_extend("force", opts, { desc = "[J]ava Extract [V]ariable" }))
+  vim.keymap.set("n", "<leader>jc", jdtls.extract_constant, vim.tbl_extend("force", opts, { desc = "[J]ava Extract [C]onstant" }))
+  vim.keymap.set("v", "<leader>jc", function() jdtls.extract_constant(true) end, vim.tbl_extend("force", opts, { desc = "[J]ava Extract [C]onstant" }))
+  vim.keymap.set("v", "<leader>jm", function() jdtls.extract_method(true) end, vim.tbl_extend("force", opts, { desc = "[J]ava Extract [M]ethod" }))
+
+  -- Test commands
+  vim.keymap.set("n", "<leader>jt", jdtls.test_class, vim.tbl_extend("force", opts, { desc = "[J]ava [T]est Class" }))
+  vim.keymap.set("n", "<leader>jn", jdtls.test_nearest_method, vim.tbl_extend("force", opts, { desc = "[J]ava Test [N]earest Method" }))
+
+  -- Update project configuration
+  vim.keymap.set("n", "<leader>ju", "<Cmd>JdtUpdateConfig<CR>", vim.tbl_extend("force", opts, { desc = "[J]ava [U]pdate Config" }))
+
+  -- Debug commands
+  vim.keymap.set("n", "<leader>jd", function()
+    require("jdtls.dap").setup_dap_main_class_configs()
+    vim.notify("DAP main class configs updated", vim.log.levels.INFO)
+  end, vim.tbl_extend("force", opts, { desc = "[J]ava Setup [D]AP" }))
+end
+
+-- Callback when JDTLS attaches
+local function on_attach(client, bufnr)
+  -- Setup keymaps
+  java_keymaps(bufnr)
+
+  -- Setup DAP
+  if #bundles > 0 then
+    require("jdtls.dap").setup_dap()
+    require("jdtls.dap").setup_dap_main_class_configs()
+  end
+
+  -- Enable jdtls commands
+  require("jdtls.setup").add_commands()
+
+  vim.notify("JDTLS attached to buffer", vim.log.levels.INFO)
+end
+
+-- Get capabilities from nvchad's lspconfig defaults
+local capabilities = vim.lsp.protocol.make_client_capabilities()
+local cmp_ok, cmp_nvim_lsp = pcall(require, "cmp_nvim_lsp")
+if cmp_ok then
+  capabilities = cmp_nvim_lsp.default_capabilities(capabilities)
+end
+
+-- Extended capabilities for JDTLS
+local extendedClientCapabilities = jdtls.extendedClientCapabilities
+extendedClientCapabilities.resolveAdditionalTextEditsSupport = true
+
+-- JDTLS configuration
+local config = {
+  cmd = cmd,
+  root_dir = get_project_root(),
+  capabilities = capabilities,
+  on_attach = on_attach,
+
+  settings = {
+    java = {
+      format = {
+        enabled = true,
+        settings = {
+          url = vim.fn.stdpath "config" .. "/java-formatter.xml",
+          profile = "GoogleStyle",
+        },
+      },
+      signatureHelp = { enabled = true },
+      contentProvider = { preferred = "fernflower" },
+      completion = {
+        favoriteStaticMembers = {
+          "org.junit.Assert.*",
+          "org.junit.Assume.*",
+          "org.junit.jupiter.api.Assertions.*",
+          "org.junit.jupiter.api.Assumptions.*",
+          "org.junit.jupiter.api.DynamicContainer.*",
+          "org.junit.jupiter.api.DynamicTest.*",
+          "org.mockito.Mockito.*",
+          "org.mockito.ArgumentMatchers.*",
+          "org.mockito.Answers.*",
+        },
+        filteredTypes = {
+          "com.sun.*",
+          "io.micrometer.shaded.*",
+          "java.awt.*",
+          "jdk.*",
+          "sun.*",
+        },
+        importOrder = {
+          "java",
+          "javax",
+          "com",
+          "org",
+        },
+      },
+      sources = {
+        organizeImports = {
+          starThreshold = 9999,
+          staticStarThreshold = 9999,
+        },
+      },
+      codeGeneration = {
+        toString = {
+          template = "${object.className}{${member.name()}=${member.value}, ${otherMembers}}",
+        },
+        useBlocks = true,
+      },
+      configuration = {
+        updateBuildConfiguration = "interactive",
+      },
+      maven = {
+        downloadSources = true,
+      },
+      implementationsCodeLens = {
+        enabled = true,
+      },
+      referencesCodeLens = {
+        enabled = true,
+      },
+      inlayHints = {
+        parameterNames = {
+          enabled = "all",
+        },
+      },
+    },
+  },
+
+  init_options = {
+    bundles = bundles,
+    extendedClientCapabilities = extendedClientCapabilities,
+  },
+}
+
+-- Start or attach to JDTLS
+jdtls.start_or_attach(config)

--- a/dot_config/nvim/ftplugin/java.lua
+++ b/dot_config/nvim/ftplugin/java.lua
@@ -1,289 +1,328 @@
 -- Java-specific settings and JDTLS configuration
 -- This file is loaded automatically when opening Java files
 
-local jdtls_ok, jdtls = pcall(require, "jdtls")
-if not jdtls_ok then
-  vim.notify("nvim-jdtls not found, Java LSP will not be available", vim.log.levels.WARN)
-  return
-end
-
--- Utility function to find the root directory of a Java project
-local function get_project_root()
-  return vim.fs.root(0, { ".git", "mvnw", "gradlew", "pom.xml", "build.gradle" }) or vim.fn.getcwd()
-end
-
--- Get Mason registry for tool paths
-local mason_registry_ok, mason_registry = pcall(require, "mason-registry")
-if not mason_registry_ok then
-  vim.notify("Mason registry not found", vim.log.levels.WARN)
-  return
-end
-
--- Wait for mason to be ready
-if not mason_registry.is_installed "jdtls" then
-  vim.notify("jdtls not installed via Mason. Run :MasonInstall jdtls", vim.log.levels.WARN)
-  return
-end
-
--- Get paths from Mason
-local jdtls_pkg = mason_registry.get_package "jdtls"
-local jdtls_path = jdtls_pkg:get_install_path()
-
--- Find the launcher jar
-local launcher_jar = vim.fn.glob(jdtls_path .. "/plugins/org.eclipse.equinox.launcher_*.jar")
-if launcher_jar == "" then
-  vim.notify("JDTLS launcher jar not found", vim.log.levels.ERROR)
-  return
-end
-
--- Determine OS-specific config directory
-local os_config
-if vim.fn.has "mac" == 1 then
-  os_config = jdtls_path .. "/config_mac"
-elseif vim.fn.has "unix" == 1 then
-  os_config = jdtls_path .. "/config_linux"
-else
-  os_config = jdtls_path .. "/config_win"
-end
-
--- Lombok support (bundled with Mason's jdtls)
-local lombok_jar = jdtls_path .. "/lombok.jar"
-local lombok_agent = ""
-if vim.fn.filereadable(lombok_jar) == 1 then
-  lombok_agent = "-javaagent:" .. lombok_jar
-end
-
--- Workspace directory for JDTLS (per-project)
-local project_name = vim.fn.fnamemodify(get_project_root(), ":p:h:t")
-local workspace_dir = vim.fn.stdpath "data" .. "/jdtls-workspace/" .. project_name
-
--- Find Java executable
--- Supports SDKMAN, JAVA_HOME, or system java
-local function get_java_executable()
-  -- Check SDKMAN current java
-  local sdkman_java = vim.fn.expand "$HOME/.sdkman/candidates/java/current/bin/java"
-  if vim.fn.executable(sdkman_java) == 1 then
-    return sdkman_java
+-- Wrap everything in a function to defer execution
+local function setup_jdtls()
+  local jdtls_ok, jdtls = pcall(require, "jdtls")
+  if not jdtls_ok then
+    vim.notify("nvim-jdtls not found. Run :Lazy sync to install plugins", vim.log.levels.WARN)
+    return
   end
 
-  -- Check JAVA_HOME
-  local java_home = os.getenv "JAVA_HOME"
-  if java_home then
-    local java_from_home = java_home .. "/bin/java"
-    if vim.fn.executable(java_from_home) == 1 then
-      return java_from_home
+  -- Get Mason registry for tool paths
+  local mason_registry_ok, mason_registry = pcall(require, "mason-registry")
+  if not mason_registry_ok then
+    vim.notify("Mason registry not found. Run :Lazy sync to install plugins", vim.log.levels.WARN)
+    return
+  end
+
+  -- Ensure Mason registry is refreshed
+  if not mason_registry.is_installed "jdtls" then
+    vim.notify("jdtls not installed. Run :MasonInstall jdtls", vim.log.levels.WARN)
+    return
+  end
+
+  -- Safely get the jdtls package
+  local jdtls_pkg_ok, jdtls_pkg = pcall(mason_registry.get_package, "jdtls")
+  if not jdtls_pkg_ok or not jdtls_pkg then
+    vim.notify("Could not get jdtls package from Mason registry", vim.log.levels.WARN)
+    return
+  end
+
+  -- Safely get install path
+  local path_ok, jdtls_path = pcall(function()
+    return jdtls_pkg:get_install_path()
+  end)
+  if not path_ok or not jdtls_path then
+    vim.notify("Could not get jdtls install path. Mason may still be initializing.", vim.log.levels.WARN)
+    return
+  end
+
+  -- Find the launcher jar
+  local launcher_jar = vim.fn.glob(jdtls_path .. "/plugins/org.eclipse.equinox.launcher_*.jar")
+  if launcher_jar == "" then
+    vim.notify("JDTLS launcher jar not found at " .. jdtls_path, vim.log.levels.ERROR)
+    return
+  end
+
+  -- Determine OS-specific config directory
+  local os_config
+  if vim.fn.has "mac" == 1 then
+    os_config = jdtls_path .. "/config_mac"
+  elseif vim.fn.has "unix" == 1 then
+    os_config = jdtls_path .. "/config_linux"
+  else
+    os_config = jdtls_path .. "/config_win"
+  end
+
+  -- Lombok support (bundled with Mason's jdtls)
+  local lombok_jar = jdtls_path .. "/lombok.jar"
+  local lombok_agent = ""
+  if vim.fn.filereadable(lombok_jar) == 1 then
+    lombok_agent = "-javaagent:" .. lombok_jar
+  end
+
+  -- Utility function to find the root directory of a Java project
+  local function get_project_root()
+    return vim.fs.root(0, { ".git", "mvnw", "gradlew", "pom.xml", "build.gradle" }) or vim.fn.getcwd()
+  end
+
+  -- Workspace directory for JDTLS (per-project)
+  local project_name = vim.fn.fnamemodify(get_project_root(), ":p:h:t")
+  local workspace_dir = vim.fn.stdpath "data" .. "/jdtls-workspace/" .. project_name
+
+  -- Find Java executable
+  -- Supports SDKMAN, JAVA_HOME, or system java
+  local function get_java_executable()
+    -- Check SDKMAN current java
+    local sdkman_java = vim.fn.expand "$HOME/.sdkman/candidates/java/current/bin/java"
+    if vim.fn.executable(sdkman_java) == 1 then
+      return sdkman_java
+    end
+
+    -- Check JAVA_HOME
+    local java_home = os.getenv "JAVA_HOME"
+    if java_home then
+      local java_from_home = java_home .. "/bin/java"
+      if vim.fn.executable(java_from_home) == 1 then
+        return java_from_home
+      end
+    end
+
+    -- Fallback to system java
+    if vim.fn.executable "java" == 1 then
+      return "java"
+    end
+
+    return nil
+  end
+
+  local java_cmd = get_java_executable()
+  if not java_cmd then
+    vim.notify("No Java executable found. Install Java 17+ via SDKMAN or set JAVA_HOME", vim.log.levels.ERROR)
+    return
+  end
+
+  -- Debug adapter paths (if installed)
+  local bundles = {}
+
+  -- Add java-debug-adapter
+  if mason_registry.is_installed "java-debug-adapter" then
+    local ok, java_debug_pkg = pcall(mason_registry.get_package, "java-debug-adapter")
+    if ok and java_debug_pkg then
+      local debug_path_ok, java_debug_path = pcall(function()
+        return java_debug_pkg:get_install_path()
+      end)
+      if debug_path_ok and java_debug_path then
+        local debug_jar = vim.fn.glob(java_debug_path .. "/extension/server/com.microsoft.java.debug.plugin-*.jar", true)
+        if debug_jar ~= "" then
+          table.insert(bundles, debug_jar)
+        end
+      end
     end
   end
 
-  -- Fallback to system java
-  if vim.fn.executable "java" == 1 then
-    return "java"
-  end
-
-  vim.notify("No Java executable found. Please install Java 17+ via SDKMAN or set JAVA_HOME", vim.log.levels.ERROR)
-  return nil
-end
-
-local java_cmd = get_java_executable()
-if not java_cmd then
-  return
-end
-
--- Debug adapter paths (if installed)
-local bundles = {}
-
--- Add java-debug-adapter
-if mason_registry.is_installed "java-debug-adapter" then
-  local java_debug_pkg = mason_registry.get_package "java-debug-adapter"
-  local java_debug_path = java_debug_pkg:get_install_path()
-  local debug_jar = vim.fn.glob(java_debug_path .. "/extension/server/com.microsoft.java.debug.plugin-*.jar", true)
-  if debug_jar ~= "" then
-    table.insert(bundles, debug_jar)
-  end
-end
-
--- Add java-test
-if mason_registry.is_installed "java-test" then
-  local java_test_pkg = mason_registry.get_package "java-test"
-  local java_test_path = java_test_pkg:get_install_path()
-  local test_jars = vim.fn.glob(java_test_path .. "/extension/server/*.jar", true, true)
-  for _, jar in ipairs(test_jars) do
-    if not vim.endswith(jar, "com.microsoft.java.test.runner-jar-with-dependencies.jar") then
-      table.insert(bundles, jar)
+  -- Add java-test
+  if mason_registry.is_installed "java-test" then
+    local ok, java_test_pkg = pcall(mason_registry.get_package, "java-test")
+    if ok and java_test_pkg then
+      local test_path_ok, java_test_path = pcall(function()
+        return java_test_pkg:get_install_path()
+      end)
+      if test_path_ok and java_test_path then
+        local test_jars = vim.fn.glob(java_test_path .. "/extension/server/*.jar", true, true)
+        for _, jar in ipairs(test_jars) do
+          if not vim.endswith(jar, "com.microsoft.java.test.runner-jar-with-dependencies.jar") then
+            table.insert(bundles, jar)
+          end
+        end
+      end
     end
   end
-end
 
--- Build the command to start JDTLS
-local cmd = {
-  java_cmd,
-  "-Declipse.application=org.eclipse.jdt.ls.core.id1",
-  "-Dosgi.bundles.defaultStartLevel=4",
-  "-Declipse.product=org.eclipse.jdt.ls.core.product",
-  "-Dlog.protocol=true",
-  "-Dlog.level=ALL",
-  "-Xms1g",
-  "-Xmx2G",
-  "--add-modules=ALL-SYSTEM",
-  "--add-opens",
-  "java.base/java.util=ALL-UNNAMED",
-  "--add-opens",
-  "java.base/java.lang=ALL-UNNAMED",
-}
+  -- Build the command to start JDTLS
+  local cmd = {
+    java_cmd,
+    "-Declipse.application=org.eclipse.jdt.ls.core.id1",
+    "-Dosgi.bundles.defaultStartLevel=4",
+    "-Declipse.product=org.eclipse.jdt.ls.core.product",
+    "-Dlog.protocol=true",
+    "-Dlog.level=ALL",
+    "-Xms1g",
+    "-Xmx2G",
+    "--add-modules=ALL-SYSTEM",
+    "--add-opens",
+    "java.base/java.util=ALL-UNNAMED",
+    "--add-opens",
+    "java.base/java.lang=ALL-UNNAMED",
+  }
 
--- Add lombok agent if available
-if lombok_agent ~= "" then
-  table.insert(cmd, lombok_agent)
-end
-
--- Add JVM arg to prevent metadata files in project root
-table.insert(cmd, "--jvm-arg=-Djava.import.generatesMetadataFilesAtProjectRoot=false")
-
--- Add jar, config, and data arguments
-vim.list_extend(cmd, {
-  "-jar",
-  launcher_jar,
-  "-configuration",
-  os_config,
-  "-data",
-  workspace_dir,
-})
-
--- Java-specific keymaps
-local function java_keymaps(bufnr)
-  local opts = { noremap = true, silent = true, buffer = bufnr }
-
-  -- JDTLS specific commands
-  vim.keymap.set("n", "<leader>jo", jdtls.organize_imports, vim.tbl_extend("force", opts, { desc = "[J]ava [O]rganize Imports" }))
-  vim.keymap.set("n", "<leader>jv", jdtls.extract_variable, vim.tbl_extend("force", opts, { desc = "[J]ava Extract [V]ariable" }))
-  vim.keymap.set("v", "<leader>jv", function() jdtls.extract_variable(true) end, vim.tbl_extend("force", opts, { desc = "[J]ava Extract [V]ariable" }))
-  vim.keymap.set("n", "<leader>jc", jdtls.extract_constant, vim.tbl_extend("force", opts, { desc = "[J]ava Extract [C]onstant" }))
-  vim.keymap.set("v", "<leader>jc", function() jdtls.extract_constant(true) end, vim.tbl_extend("force", opts, { desc = "[J]ava Extract [C]onstant" }))
-  vim.keymap.set("v", "<leader>jm", function() jdtls.extract_method(true) end, vim.tbl_extend("force", opts, { desc = "[J]ava Extract [M]ethod" }))
-
-  -- Test commands
-  vim.keymap.set("n", "<leader>jt", jdtls.test_class, vim.tbl_extend("force", opts, { desc = "[J]ava [T]est Class" }))
-  vim.keymap.set("n", "<leader>jn", jdtls.test_nearest_method, vim.tbl_extend("force", opts, { desc = "[J]ava Test [N]earest Method" }))
-
-  -- Update project configuration
-  vim.keymap.set("n", "<leader>ju", "<Cmd>JdtUpdateConfig<CR>", vim.tbl_extend("force", opts, { desc = "[J]ava [U]pdate Config" }))
-
-  -- Debug commands
-  vim.keymap.set("n", "<leader>jd", function()
-    require("jdtls.dap").setup_dap_main_class_configs()
-    vim.notify("DAP main class configs updated", vim.log.levels.INFO)
-  end, vim.tbl_extend("force", opts, { desc = "[J]ava Setup [D]AP" }))
-end
-
--- Callback when JDTLS attaches
-local function on_attach(client, bufnr)
-  -- Setup keymaps
-  java_keymaps(bufnr)
-
-  -- Setup DAP
-  if #bundles > 0 then
-    require("jdtls.dap").setup_dap()
-    require("jdtls.dap").setup_dap_main_class_configs()
+  -- Add lombok agent if available
+  if lombok_agent ~= "" then
+    table.insert(cmd, lombok_agent)
   end
 
-  -- Enable jdtls commands
-  require("jdtls.setup").add_commands()
+  -- Add JVM arg to prevent metadata files in project root
+  table.insert(cmd, "--jvm-arg=-Djava.import.generatesMetadataFilesAtProjectRoot=false")
 
-  vim.notify("JDTLS attached to buffer", vim.log.levels.INFO)
-end
+  -- Add jar, config, and data arguments
+  vim.list_extend(cmd, {
+    "-jar",
+    launcher_jar,
+    "-configuration",
+    os_config,
+    "-data",
+    workspace_dir,
+  })
 
--- Get capabilities from nvchad's lspconfig defaults
-local capabilities = vim.lsp.protocol.make_client_capabilities()
-local cmp_ok, cmp_nvim_lsp = pcall(require, "cmp_nvim_lsp")
-if cmp_ok then
-  capabilities = cmp_nvim_lsp.default_capabilities(capabilities)
-end
+  -- Java-specific keymaps
+  local function java_keymaps(bufnr)
+    local opts = { noremap = true, silent = true, buffer = bufnr }
 
--- Extended capabilities for JDTLS
-local extendedClientCapabilities = jdtls.extendedClientCapabilities
-extendedClientCapabilities.resolveAdditionalTextEditsSupport = true
+    -- JDTLS specific commands
+    vim.keymap.set("n", "<leader>jo", jdtls.organize_imports, vim.tbl_extend("force", opts, { desc = "[J]ava [O]rganize Imports" }))
+    vim.keymap.set("n", "<leader>jv", jdtls.extract_variable, vim.tbl_extend("force", opts, { desc = "[J]ava Extract [V]ariable" }))
+    vim.keymap.set("v", "<leader>jv", function()
+      jdtls.extract_variable(true)
+    end, vim.tbl_extend("force", opts, { desc = "[J]ava Extract [V]ariable" }))
+    vim.keymap.set("n", "<leader>jc", jdtls.extract_constant, vim.tbl_extend("force", opts, { desc = "[J]ava Extract [C]onstant" }))
+    vim.keymap.set("v", "<leader>jc", function()
+      jdtls.extract_constant(true)
+    end, vim.tbl_extend("force", opts, { desc = "[J]ava Extract [C]onstant" }))
+    vim.keymap.set("v", "<leader>jm", function()
+      jdtls.extract_method(true)
+    end, vim.tbl_extend("force", opts, { desc = "[J]ava Extract [M]ethod" }))
 
--- JDTLS configuration
-local config = {
-  cmd = cmd,
-  root_dir = get_project_root(),
-  capabilities = capabilities,
-  on_attach = on_attach,
+    -- Test commands
+    vim.keymap.set("n", "<leader>jt", jdtls.test_class, vim.tbl_extend("force", opts, { desc = "[J]ava [T]est Class" }))
+    vim.keymap.set("n", "<leader>jn", jdtls.test_nearest_method, vim.tbl_extend("force", opts, { desc = "[J]ava Test [N]earest Method" }))
 
-  settings = {
-    java = {
-      format = {
-        enabled = true,
-        settings = {
-          url = vim.fn.stdpath "config" .. "/java-formatter.xml",
-          profile = "GoogleStyle",
+    -- Update project configuration
+    vim.keymap.set("n", "<leader>ju", "<Cmd>JdtUpdateConfig<CR>", vim.tbl_extend("force", opts, { desc = "[J]ava [U]pdate Config" }))
+
+    -- Debug commands
+    vim.keymap.set("n", "<leader>jd", function()
+      require("jdtls.dap").setup_dap_main_class_configs()
+      vim.notify("DAP main class configs updated", vim.log.levels.INFO)
+    end, vim.tbl_extend("force", opts, { desc = "[J]ava Setup [D]AP" }))
+  end
+
+  -- Callback when JDTLS attaches
+  local function on_attach(client, bufnr)
+    -- Setup keymaps
+    java_keymaps(bufnr)
+
+    -- Setup DAP
+    if #bundles > 0 then
+      require("jdtls.dap").setup_dap()
+      require("jdtls.dap").setup_dap_main_class_configs()
+    end
+
+    -- Enable jdtls commands
+    require("jdtls.setup").add_commands()
+
+    vim.notify("JDTLS attached to buffer", vim.log.levels.INFO)
+  end
+
+  -- Get capabilities from nvchad's lspconfig defaults
+  local capabilities = vim.lsp.protocol.make_client_capabilities()
+  local cmp_ok, cmp_nvim_lsp = pcall(require, "cmp_nvim_lsp")
+  if cmp_ok then
+    capabilities = cmp_nvim_lsp.default_capabilities(capabilities)
+  end
+
+  -- Extended capabilities for JDTLS
+  local extendedClientCapabilities = jdtls.extendedClientCapabilities
+  extendedClientCapabilities.resolveAdditionalTextEditsSupport = true
+
+  -- JDTLS configuration
+  local config = {
+    cmd = cmd,
+    root_dir = get_project_root(),
+    capabilities = capabilities,
+    on_attach = on_attach,
+
+    settings = {
+      java = {
+        format = {
+          enabled = true,
+          settings = {
+            url = vim.fn.stdpath "config" .. "/java-formatter.xml",
+            profile = "GoogleStyle",
+          },
         },
-      },
-      signatureHelp = { enabled = true },
-      contentProvider = { preferred = "fernflower" },
-      completion = {
-        favoriteStaticMembers = {
-          "org.junit.Assert.*",
-          "org.junit.Assume.*",
-          "org.junit.jupiter.api.Assertions.*",
-          "org.junit.jupiter.api.Assumptions.*",
-          "org.junit.jupiter.api.DynamicContainer.*",
-          "org.junit.jupiter.api.DynamicTest.*",
-          "org.mockito.Mockito.*",
-          "org.mockito.ArgumentMatchers.*",
-          "org.mockito.Answers.*",
+        signatureHelp = { enabled = true },
+        contentProvider = { preferred = "fernflower" },
+        completion = {
+          favoriteStaticMembers = {
+            "org.junit.Assert.*",
+            "org.junit.Assume.*",
+            "org.junit.jupiter.api.Assertions.*",
+            "org.junit.jupiter.api.Assumptions.*",
+            "org.junit.jupiter.api.DynamicContainer.*",
+            "org.junit.jupiter.api.DynamicTest.*",
+            "org.mockito.Mockito.*",
+            "org.mockito.ArgumentMatchers.*",
+            "org.mockito.Answers.*",
+          },
+          filteredTypes = {
+            "com.sun.*",
+            "io.micrometer.shaded.*",
+            "java.awt.*",
+            "jdk.*",
+            "sun.*",
+          },
+          importOrder = {
+            "java",
+            "javax",
+            "com",
+            "org",
+          },
         },
-        filteredTypes = {
-          "com.sun.*",
-          "io.micrometer.shaded.*",
-          "java.awt.*",
-          "jdk.*",
-          "sun.*",
+        sources = {
+          organizeImports = {
+            starThreshold = 9999,
+            staticStarThreshold = 9999,
+          },
         },
-        importOrder = {
-          "java",
-          "javax",
-          "com",
-          "org",
+        codeGeneration = {
+          toString = {
+            template = "${object.className}{${member.name()}=${member.value}, ${otherMembers}}",
+          },
+          useBlocks = true,
         },
-      },
-      sources = {
-        organizeImports = {
-          starThreshold = 9999,
-          staticStarThreshold = 9999,
+        configuration = {
+          updateBuildConfiguration = "interactive",
         },
-      },
-      codeGeneration = {
-        toString = {
-          template = "${object.className}{${member.name()}=${member.value}, ${otherMembers}}",
+        maven = {
+          downloadSources = true,
         },
-        useBlocks = true,
-      },
-      configuration = {
-        updateBuildConfiguration = "interactive",
-      },
-      maven = {
-        downloadSources = true,
-      },
-      implementationsCodeLens = {
-        enabled = true,
-      },
-      referencesCodeLens = {
-        enabled = true,
-      },
-      inlayHints = {
-        parameterNames = {
-          enabled = "all",
+        implementationsCodeLens = {
+          enabled = true,
+        },
+        referencesCodeLens = {
+          enabled = true,
+        },
+        inlayHints = {
+          parameterNames = {
+            enabled = "all",
+          },
         },
       },
     },
-  },
 
-  init_options = {
-    bundles = bundles,
-    extendedClientCapabilities = extendedClientCapabilities,
-  },
-}
+    init_options = {
+      bundles = bundles,
+      extendedClientCapabilities = extendedClientCapabilities,
+    },
+  }
 
--- Start or attach to JDTLS
-jdtls.start_or_attach(config)
+  -- Start or attach to JDTLS
+  jdtls.start_or_attach(config)
+end
+
+-- Run setup, catching any errors gracefully
+local ok, err = pcall(setup_jdtls)
+if not ok then
+  vim.notify("JDTLS setup error: " .. tostring(err), vim.log.levels.WARN)
+end

--- a/dot_config/nvim/ftplugin/java.lua
+++ b/dot_config/nvim/ftplugin/java.lua
@@ -9,68 +9,6 @@ local function setup_jdtls()
     return
   end
 
-  -- Get Mason registry for tool paths
-  local mason_registry_ok, mason_registry = pcall(require, "mason-registry")
-  if not mason_registry_ok then
-    vim.notify("Mason registry not found. Run :Lazy sync to install plugins", vim.log.levels.WARN)
-    return
-  end
-
-  -- Ensure Mason registry is refreshed
-  if not mason_registry.is_installed "jdtls" then
-    vim.notify("jdtls not installed. Run :MasonInstall jdtls", vim.log.levels.WARN)
-    return
-  end
-
-  -- Safely get the jdtls package
-  local jdtls_pkg_ok, jdtls_pkg = pcall(mason_registry.get_package, "jdtls")
-  if not jdtls_pkg_ok or not jdtls_pkg then
-    vim.notify("Could not get jdtls package from Mason registry", vim.log.levels.WARN)
-    return
-  end
-
-  -- Safely get install path
-  local path_ok, jdtls_path = pcall(function()
-    return jdtls_pkg:get_install_path()
-  end)
-  if not path_ok or not jdtls_path then
-    vim.notify("Could not get jdtls install path. Mason may still be initializing.", vim.log.levels.WARN)
-    return
-  end
-
-  -- Find the launcher jar
-  local launcher_jar = vim.fn.glob(jdtls_path .. "/plugins/org.eclipse.equinox.launcher_*.jar")
-  if launcher_jar == "" then
-    vim.notify("JDTLS launcher jar not found at " .. jdtls_path, vim.log.levels.ERROR)
-    return
-  end
-
-  -- Determine OS-specific config directory
-  local os_config
-  if vim.fn.has "mac" == 1 then
-    os_config = jdtls_path .. "/config_mac"
-  elseif vim.fn.has "unix" == 1 then
-    os_config = jdtls_path .. "/config_linux"
-  else
-    os_config = jdtls_path .. "/config_win"
-  end
-
-  -- Lombok support (bundled with Mason's jdtls)
-  local lombok_jar = jdtls_path .. "/lombok.jar"
-  local lombok_agent = ""
-  if vim.fn.filereadable(lombok_jar) == 1 then
-    lombok_agent = "-javaagent:" .. lombok_jar
-  end
-
-  -- Utility function to find the root directory of a Java project
-  local function get_project_root()
-    return vim.fs.root(0, { ".git", "mvnw", "gradlew", "pom.xml", "build.gradle" }) or vim.fn.getcwd()
-  end
-
-  -- Workspace directory for JDTLS (per-project)
-  local project_name = vim.fn.fnamemodify(get_project_root(), ":p:h:t")
-  local workspace_dir = vim.fn.stdpath "data" .. "/jdtls-workspace/" .. project_name
-
   -- Find Java executable
   -- Supports SDKMAN, JAVA_HOME, or system java
   local function get_java_executable()
@@ -103,40 +41,155 @@ local function setup_jdtls()
     return
   end
 
-  -- Debug adapter paths (if installed)
+  -- Find JDTLS installation
+  -- Priority: 1) Manual install 2) Mason 3) Homebrew
+  local function find_jdtls()
+    local jdtls_locations = {
+      -- Manual installation in data directory (recommended)
+      vim.fn.stdpath "data" .. "/jdtls",
+      -- XDG data location
+      vim.fn.expand "$HOME/.local/share/jdtls",
+      -- Homebrew on macOS
+      "/opt/homebrew/opt/jdtls",
+      "/usr/local/opt/jdtls",
+      -- Linux package managers
+      "/usr/share/java/jdtls",
+    }
+
+    -- Also check Mason if available
+    local mason_registry_ok, mason_registry = pcall(require, "mason-registry")
+    if mason_registry_ok then
+      local ok, is_installed = pcall(mason_registry.is_installed, "jdtls")
+      if ok and is_installed then
+        local pkg_ok, jdtls_pkg = pcall(mason_registry.get_package, "jdtls")
+        if pkg_ok and jdtls_pkg then
+          local path_ok, mason_path = pcall(function()
+            return jdtls_pkg:get_install_path()
+          end)
+          if path_ok and mason_path then
+            table.insert(jdtls_locations, 1, mason_path)
+          end
+        end
+      end
+    end
+
+    for _, location in ipairs(jdtls_locations) do
+      local launcher = vim.fn.glob(location .. "/plugins/org.eclipse.equinox.launcher_*.jar")
+      if launcher ~= "" then
+        return location, launcher
+      end
+    end
+
+    return nil, nil
+  end
+
+  local jdtls_home, launcher_jar = find_jdtls()
+
+  if not jdtls_home then
+    vim.notify(
+      "JDTLS not found. Install it manually:\n"
+        .. "  mkdir -p ~/.local/share/jdtls\n"
+        .. "  cd ~/.local/share/jdtls\n"
+        .. "  curl -L -o jdtls.tar.gz https://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz\n"
+        .. "  tar -xzf jdtls.tar.gz\n"
+        .. "  rm jdtls.tar.gz",
+      vim.log.levels.WARN
+    )
+    return
+  end
+
+  -- Determine OS-specific config directory
+  local os_config
+  if vim.fn.has "mac" == 1 then
+    os_config = jdtls_home .. "/config_mac"
+  elseif vim.fn.has "unix" == 1 then
+    os_config = jdtls_home .. "/config_linux"
+  else
+    os_config = jdtls_home .. "/config_win"
+  end
+
+  -- Lombok support
+  local lombok_jar = jdtls_home .. "/lombok.jar"
+  local lombok_agent = ""
+  if vim.fn.filereadable(lombok_jar) == 1 then
+    lombok_agent = "-javaagent:" .. lombok_jar
+  end
+
+  -- Utility function to find the root directory of a Java project
+  local function get_project_root()
+    return vim.fs.root(0, { ".git", "mvnw", "gradlew", "pom.xml", "build.gradle" }) or vim.fn.getcwd()
+  end
+
+  -- Workspace directory for JDTLS (per-project)
+  local project_name = vim.fn.fnamemodify(get_project_root(), ":p:h:t")
+  local workspace_dir = vim.fn.stdpath "data" .. "/jdtls-workspace/" .. project_name
+
+  -- Debug adapter bundles (optional)
   local bundles = {}
 
-  -- Add java-debug-adapter
-  if mason_registry.is_installed "java-debug-adapter" then
-    local ok, java_debug_pkg = pcall(mason_registry.get_package, "java-debug-adapter")
-    if ok and java_debug_pkg then
-      local debug_path_ok, java_debug_path = pcall(function()
-        return java_debug_pkg:get_install_path()
-      end)
-      if debug_path_ok and java_debug_path then
-        local debug_jar = vim.fn.glob(java_debug_path .. "/extension/server/com.microsoft.java.debug.plugin-*.jar", true)
-        if debug_jar ~= "" then
-          table.insert(bundles, debug_jar)
+  -- Look for java-debug-adapter
+  local debug_locations = {
+    vim.fn.stdpath "data" .. "/java-debug/com.microsoft.java.debug.plugin/target",
+    vim.fn.expand "$HOME/.local/share/java-debug",
+  }
+
+  -- Check Mason for java-debug-adapter
+  local mason_registry_ok, mason_registry = pcall(require, "mason-registry")
+  if mason_registry_ok then
+    local ok, is_installed = pcall(mason_registry.is_installed, "java-debug-adapter")
+    if ok and is_installed then
+      local pkg_ok, pkg = pcall(mason_registry.get_package, "java-debug-adapter")
+      if pkg_ok and pkg then
+        local path_ok, path = pcall(function()
+          return pkg:get_install_path()
+        end)
+        if path_ok and path then
+          table.insert(debug_locations, 1, path .. "/extension/server")
         end
       end
     end
   end
 
-  -- Add java-test
-  if mason_registry.is_installed "java-test" then
-    local ok, java_test_pkg = pcall(mason_registry.get_package, "java-test")
-    if ok and java_test_pkg then
-      local test_path_ok, java_test_path = pcall(function()
-        return java_test_pkg:get_install_path()
-      end)
-      if test_path_ok and java_test_path then
-        local test_jars = vim.fn.glob(java_test_path .. "/extension/server/*.jar", true, true)
-        for _, jar in ipairs(test_jars) do
-          if not vim.endswith(jar, "com.microsoft.java.test.runner-jar-with-dependencies.jar") then
-            table.insert(bundles, jar)
-          end
+  for _, location in ipairs(debug_locations) do
+    local debug_jar = vim.fn.glob(location .. "/com.microsoft.java.debug.plugin-*.jar", true)
+    if debug_jar ~= "" then
+      table.insert(bundles, debug_jar)
+      break
+    end
+  end
+
+  -- Look for java-test
+  local test_locations = {
+    vim.fn.stdpath "data" .. "/vscode-java-test/server",
+    vim.fn.expand "$HOME/.local/share/vscode-java-test/server",
+  }
+
+  -- Check Mason for java-test
+  if mason_registry_ok then
+    local ok, is_installed = pcall(mason_registry.is_installed, "java-test")
+    if ok and is_installed then
+      local pkg_ok, pkg = pcall(mason_registry.get_package, "java-test")
+      if pkg_ok and pkg then
+        local path_ok, path = pcall(function()
+          return pkg:get_install_path()
+        end)
+        if path_ok and path then
+          table.insert(test_locations, 1, path .. "/extension/server")
         end
       end
+    end
+  end
+
+  for _, location in ipairs(test_locations) do
+    local test_jars = vim.fn.glob(location .. "/*.jar", true, true)
+    if #test_jars > 0 then
+      for _, jar in ipairs(test_jars) do
+        local fname = vim.fn.fnamemodify(jar, ":t")
+        if fname ~= "com.microsoft.java.test.runner-jar-with-dependencies.jar" and fname ~= "jacocoagent.jar" then
+          table.insert(bundles, jar)
+        end
+      end
+      break
     end
   end
 
@@ -163,7 +216,7 @@ local function setup_jdtls()
   end
 
   -- Add JVM arg to prevent metadata files in project root
-  table.insert(cmd, "--jvm-arg=-Djava.import.generatesMetadataFilesAtProjectRoot=false")
+  table.insert(cmd, "-Djava.import.generatesMetadataFilesAtProjectRoot=false")
 
   -- Add jar, config, and data arguments
   vim.list_extend(cmd, {
@@ -212,7 +265,7 @@ local function setup_jdtls()
     -- Setup keymaps
     java_keymaps(bufnr)
 
-    -- Setup DAP
+    -- Setup DAP if bundles are available
     if #bundles > 0 then
       require("jdtls.dap").setup_dap()
       require("jdtls.dap").setup_dap_main_class_configs()
@@ -235,6 +288,37 @@ local function setup_jdtls()
   local extendedClientCapabilities = jdtls.extendedClientCapabilities
   extendedClientCapabilities.resolveAdditionalTextEditsSupport = true
 
+  -- Configure available Java runtimes (SDKMAN support)
+  local java_runtimes = {}
+  local sdkman_java_dir = vim.fn.expand "$HOME/.sdkman/candidates/java"
+  if vim.fn.isdirectory(sdkman_java_dir) == 1 then
+    -- Scan for installed Java versions
+    local java_versions = vim.fn.glob(sdkman_java_dir .. "/*", false, true)
+    for _, java_path in ipairs(java_versions) do
+      local version_name = vim.fn.fnamemodify(java_path, ":t")
+      if version_name ~= "current" and vim.fn.isdirectory(java_path) == 1 then
+        -- Determine the runtime name based on version
+        local runtime_name
+        if version_name:match "^21" then
+          runtime_name = "JavaSE-21"
+        elseif version_name:match "^17" then
+          runtime_name = "JavaSE-17"
+        elseif version_name:match "^11" then
+          runtime_name = "JavaSE-11"
+        elseif version_name:match "^8" or version_name:match "^1%.8" then
+          runtime_name = "JavaSE-1.8"
+        end
+
+        if runtime_name then
+          table.insert(java_runtimes, {
+            name = runtime_name,
+            path = java_path,
+          })
+        end
+      end
+    end
+  end
+
   -- JDTLS configuration
   local config = {
     cmd = cmd,
@@ -246,10 +330,6 @@ local function setup_jdtls()
       java = {
         format = {
           enabled = true,
-          settings = {
-            url = vim.fn.stdpath "config" .. "/java-formatter.xml",
-            profile = "GoogleStyle",
-          },
         },
         signatureHelp = { enabled = true },
         contentProvider = { preferred = "fernflower" },
@@ -293,6 +373,7 @@ local function setup_jdtls()
         },
         configuration = {
           updateBuildConfiguration = "interactive",
+          runtimes = java_runtimes,
         },
         maven = {
           downloadSources = true,

--- a/dot_config/nvim/lua/configs/conform.lua
+++ b/dot_config/nvim/lua/configs/conform.lua
@@ -1,8 +1,16 @@
 local options = {
   formatters_by_ft = {
     lua = { "stylua" },
+    java = { "google-java-format" },
+    xml = { "lemminx" },
     -- css = { "prettier" },
     -- html = { "prettier" },
+  },
+
+  formatters = {
+    ["google-java-format"] = {
+      prepend_args = { "--aosp" }, -- Use AOSP style (4-space indent)
+    },
   },
 
   -- format_on_save = {

--- a/dot_config/nvim/lua/configs/lspconfig.lua
+++ b/dot_config/nvim/lua/configs/lspconfig.lua
@@ -1,6 +1,26 @@
 require("nvchad.configs.lspconfig").defaults()
 
-local servers = { "html", "cssls", "ts_ls" }
+-- Note: Java (jdtls) is configured separately in ftplugin/java.lua
+-- to avoid conflicts with nvim-jdtls plugin
+local servers = { "html", "cssls", "ts_ls", "lemminx" }
 vim.lsp.enable(servers)
 
--- read :h vim.lsp.config for changing options of lsp servers 
+-- Lemminx (XML LSP) configuration for pom.xml and other XML files
+vim.lsp.config("lemminx", {
+  settings = {
+    xml = {
+      catalogs = {},
+      format = {
+        enabled = true,
+        splitAttributes = true,
+      },
+      validation = {
+        enabled = true,
+        noGrammar = "hint",
+        schema = true,
+      },
+    },
+  },
+})
+
+-- read :h vim.lsp.config for changing options of lsp servers

--- a/dot_config/nvim/lua/plugins/init.lua
+++ b/dot_config/nvim/lua/plugins/init.lua
@@ -5,7 +5,6 @@ return {
     opts = require "configs.conform",
   },
 
-  -- These are some examples, uncomment them if you want to see them work!
   {
     "neovim/nvim-lspconfig",
     config = function()
@@ -13,16 +12,37 @@ return {
     end,
   },
 
+  -- Treesitter for syntax highlighting
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = {
+      ensure_installed = {
+        -- Core
+        "vim",
+        "lua",
+        "vimdoc",
+        -- Web
+        "html",
+        "css",
+        "javascript",
+        "typescript",
+        "tsx",
+        "json",
+        -- Java ecosystem
+        "java",
+        "xml",
+        "yaml",
+        "toml",
+        "groovy", -- for Gradle
+        -- Other
+        "markdown",
+        "markdown_inline",
+        "bash",
+        "dockerfile",
+      },
+    },
+  },
+
   -- test new blink
   -- { import = "nvchad.blink.lazyspec" },
-
-  -- {
-  -- 	"nvim-treesitter/nvim-treesitter",
-  -- 	opts = {
-  -- 		ensure_installed = {
-  -- 			"vim", "lua", "vimdoc",
-  --      "html", "css"
-  -- 		},
-  -- 	},
-  -- },
 }

--- a/dot_config/nvim/lua/plugins/java.lua
+++ b/dot_config/nvim/lua/plugins/java.lua
@@ -1,29 +1,26 @@
 -- Java Development Plugin Configuration
--- Provides full Java LSP support via nvim-jdtls with Mason integration
+-- Provides full Java LSP support via nvim-jdtls
 -- Compatible with SDKMAN-managed JDKs
+--
+-- JDTLS Installation:
+--   Option 1 (Recommended): Manual install
+--     mkdir -p ~/.local/share/jdtls && cd ~/.local/share/jdtls
+--     curl -L -o jdtls.tar.gz https://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz
+--     tar -xzf jdtls.tar.gz && rm jdtls.tar.gz
+--
+--   Option 2: Homebrew (macOS)
+--     brew install jdtls
+--
+--   Option 3: Mason (may have issues)
+--     :MasonInstall jdtls
 
 return {
-  -- Mason for installing jdtls and related tools
-  {
-    "williamboman/mason.nvim",
-    opts = {
-      ensure_installed = {
-        "jdtls", -- Java Language Server
-        "java-debug-adapter", -- Java Debug Adapter
-        "java-test", -- Java Test Runner
-        "google-java-format", -- Java formatter
-        "lemminx", -- XML LSP (for pom.xml, etc.)
-      },
-    },
-  },
-
   -- nvim-jdtls for Java Language Server integration
   {
     "mfussenegger/nvim-jdtls",
     ft = "java",
     dependencies = {
-      "mfussenegger/nvim-dap", -- Debug Adapter Protocol
-      "williamboman/mason.nvim",
+      "mfussenegger/nvim-dap",
     },
   },
 
@@ -52,5 +49,21 @@ return {
         dapui.close()
       end
     end,
+  },
+
+  -- Mason for optional tooling (formatters, debug adapters)
+  -- Note: jdtls is NOT installed via Mason due to reliability issues
+  -- Install jdtls manually as described above
+  {
+    "williamboman/mason.nvim",
+    opts = {
+      ensure_installed = {
+        "google-java-format",
+        "lemminx",
+        -- Optional: uncomment if Mason works for you
+        -- "java-debug-adapter",
+        -- "java-test",
+      },
+    },
   },
 }

--- a/dot_config/nvim/lua/plugins/java.lua
+++ b/dot_config/nvim/lua/plugins/java.lua
@@ -1,0 +1,56 @@
+-- Java Development Plugin Configuration
+-- Provides full Java LSP support via nvim-jdtls with Mason integration
+-- Compatible with SDKMAN-managed JDKs
+
+return {
+  -- Mason for installing jdtls and related tools
+  {
+    "williamboman/mason.nvim",
+    opts = {
+      ensure_installed = {
+        "jdtls", -- Java Language Server
+        "java-debug-adapter", -- Java Debug Adapter
+        "java-test", -- Java Test Runner
+        "google-java-format", -- Java formatter
+        "lemminx", -- XML LSP (for pom.xml, etc.)
+      },
+    },
+  },
+
+  -- nvim-jdtls for Java Language Server integration
+  {
+    "mfussenegger/nvim-jdtls",
+    ft = "java",
+    dependencies = {
+      "mfussenegger/nvim-dap", -- Debug Adapter Protocol
+      "williamboman/mason.nvim",
+    },
+  },
+
+  -- nvim-dap for debugging support
+  {
+    "mfussenegger/nvim-dap",
+    lazy = true,
+    dependencies = {
+      "rcarriga/nvim-dap-ui",
+      "nvim-neotest/nvim-nio",
+    },
+    config = function()
+      local dap = require "dap"
+      local dapui = require "dapui"
+
+      dapui.setup()
+
+      -- Auto-open/close dap-ui
+      dap.listeners.after.event_initialized["dapui_config"] = function()
+        dapui.open()
+      end
+      dap.listeners.before.event_terminated["dapui_config"] = function()
+        dapui.close()
+      end
+      dap.listeners.before.event_exited["dapui_config"] = function()
+        dapui.close()
+      end
+    end,
+  },
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR adds comprehensive Java development support to the NvChad-based Neovim configuration, along with improved project documentation. It integrates with the recently merged SDKMAN support for automatic JDK installation.

## Changes

### Java Development Support

- **nvim-jdtls Integration**: Full Java Language Server support with:
  - Code completion, navigation, and refactoring
  - SDKMAN-managed JDK auto-detection (priority: SDKMAN → `$JAVA_HOME` → system java)
  - Auto-discovery of SDKMAN-installed Java runtimes for multi-version projects
  - Lombok annotation processing support
  - Per-project workspace isolation

- **Debugging**: nvim-dap integration with java-debug-adapter for Java debugging

- **Testing**: JUnit test runner integration via java-test

- **Keymaps**: Java-specific keymaps under `<leader>j` prefix:
  - `<leader>jo` - Organize imports
  - `<leader>jv` - Extract variable
  - `<leader>jc` - Extract constant
  - `<leader>jm` - Extract method
  - `<leader>jt` - Run test class
  - `<leader>jn` - Run nearest test
  - `<leader>ju` - Update project config
  - `<leader>jd` - Setup DAP configs

### JDTLS Installation

JDTLS (Eclipse JDT Language Server) is now included in the Homebrew dependencies for macOS. The Neovim configuration auto-detects jdtls from multiple locations:

1. Homebrew (`/opt/homebrew/opt/jdtls`) - **auto-installed on macOS**
2. `~/.local/share/jdtls` (manual install)
3. Mason (as fallback)

### LSP & Formatting

- Added `lemminx` (XML LSP) for `pom.xml` and other XML files
- Added `google-java-format` via conform.nvim (AOSP style)
- Updated lspconfig to avoid conflicts with jdtls

### Treesitter

- Added parsers for: `java`, `xml`, `yaml`, `groovy`, `dockerfile`, and more

### Documentation

- Comprehensive nvim README with:
  - JDTLS installation guide
  - Java development documentation
  - Keymap reference tables
  - Expanded troubleshooting guide with JDTLS-specific commands
- Updated main dotfiles README

## New Files

- `dot_config/nvim/lua/plugins/java.lua` - Java plugin specifications
- `dot_config/nvim/ftplugin/java.lua` - JDTLS configuration and setup

## Modified Files

- `.chezmoidata/packages.yaml` - Added `jdtls` to brew dependencies
- `dot_config/nvim/lua/configs/lspconfig.lua` - Added lemminx, jdtls note
- `dot_config/nvim/lua/configs/conform.lua` - Added google-java-format
- `dot_config/nvim/lua/plugins/init.lua` - Added Treesitter config
- `dot_config/nvim/README.md` - Comprehensive documentation
- `README.md` - Main dotfiles documentation

---

## Local Testing Instructions

### Step 1: Apply the Dotfiles Branch

```bash
# Enter chezmoi's source directory
chezmoi cd

# Fetch and checkout this branch
git fetch origin cursor/nvchad-java-configuration-24ed
git checkout cursor/nvchad-java-configuration-24ed

# Exit and apply
exit
chezmoi diff
chezmoi apply -v
```

### Step 2: Install JDTLS

**On macOS (automatic via brew):**
JDTLS will be installed automatically when chezmoi runs the package install script. If not, run:
```bash
brew install jdtls
```

**On Linux (manual install):**
```bash
mkdir -p ~/.local/share/jdtls
cd ~/.local/share/jdtls
curl -L -o jdtls.tar.gz https://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz
tar -xzf jdtls.tar.gz
rm jdtls.tar.gz
```

### Step 3: Neovim Plugin Installation

```bash
# Open Neovim
nvim
```

Inside Neovim:
```vim
" 1. Sync plugins
:Lazy sync

" 2. Install optional Mason tools
:MasonInstall google-java-format lemminx

" 3. Install Treesitter parsers
:TSInstall java xml yaml groovy

" 4. Quit and reopen
:qa
```

### Step 4: Test Java LSP

```bash
# Navigate to a Java project
cd /path/to/your/java/project

# Open a Java file
nvim src/main/java/com/example/App.java
```

Inside Neovim:
```vim
" Verify JDTLS is attached
:LspInfo

" Test keymaps
" <Space>jo  - Organize imports
" <Space>ju  - Update project config
" gd         - Go to definition
```

### Reverting Back to Main

```bash
chezmoi cd
git checkout main
exit
chezmoi apply -v
```

---

## Troubleshooting

| Issue | Solution |
|-------|----------|
| "JDTLS not found" | Run `brew install jdtls` (macOS) or install manually (Linux) |
| Plugins not installing | Run `:Lazy sync` |
| jdtls not starting | Check `:JdtShowLogs` and ensure Java 17+ (`sdk current java`) |
| Corrupted workspace | Run `:JdtWipeDataAndRestart` |
| "No Java executable found" | Run `source ~/.sdkman/bin/sdkman-init.sh` |

---

## Notes

- Requires Java 17+ (JDTLS requirement) - automatically installed via SDKMAN
- JDTLS is installed via Homebrew on macOS (added to `.chezmoidata/packages.yaml`)
- Auto-detects all SDKMAN-installed Java versions for multi-version project support
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-deb4426f-9b75-4e4c-9cd9-32d6bd2b75d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-deb4426f-9b75-4e4c-9cd9-32d6bd2b75d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

