### PR TITLE
Migrate to using SDKman over Brew temurin jdks

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -1,8 +1,25 @@
 packages:
+  # Custom install scripts that need to run before package managers
+  # These are typically tools that manage other dependencies
+  custom_install:
+    sdkman:
+      enabled: true
+      # SDKMAN installation URL - cross-platform installer
+      install_url: "https://get.sdkman.io"
+
+  # SDKman managed SDKs - format: "candidate" or "candidate@version"
+  # Use "sdk list <candidate>" to see available versions
+  # Leave version empty or omit @version to install latest stable
   sdkman:
-    - java
-    - maven
-    - springboot
+    java:
+      - "21.0.3-tem"    # Temurin 21 (LTS) - primary
+      - "17.0.11-tem"   # Temurin 17 (LTS) 
+      - "11.0.23-tem"   # Temurin 11 (LTS)
+    maven:
+      - "3.9.6"         # Latest stable Maven
+    springboot:
+      - "3.2.5"         # Spring Boot CLI
+
   npm_globals:
     - 'typescript'
     - 'typescript-language-server'
@@ -19,15 +36,13 @@ packages:
       - 'zoxide'
       - 'wget'
       - 'neovim'
-      # Todo: replace with sdkman
-      # - 'apache-flink'
+      # JVM tools now managed via SDKMAN (see packages.sdkman section)
+      # - 'apache-flink'  # Can be installed via sdkman if needed
       - 'redis'
   # See: https://www.chezmoi.io/user-guide/advanced/install-packages-declaratively/
   darwin:
     taps:
-      # Todo: Replace JDK versions with sdkman
-      # - 'AdoptOpenJDK/AdoptOpenJDK'
-      #- 'homebrew/cask-versions'
+      # Add any custom taps here
     brews:
       - 'git'
       - 'jq'
@@ -38,9 +53,9 @@ packages:
       - 'zoxide'
       - 'wget'
       - 'neovim'
-      # Todo: replace with sdkman
-      - 'maven'
-      - 'apache-flink'
+      # JVM tools now managed via SDKMAN (see packages.sdkman section)
+      # - 'maven'        # Moved to sdkman
+      # - 'apache-flink' # Can be installed via sdkman if needed
       - 'redis'
       - 'cassandra'
       - 'podman-compose'
@@ -52,8 +67,6 @@ packages:
       - 'bat'
       # A better alternative to ls: https://github.com/eza-community/eza
       - 'eza'
-      # A better alternative to tree: https://github.com/sharkdp/bat
-      - 'bat'
       # Better alternative to curl: https://github.com/ducaale/xh
       - 'xh'
       - 'opslevel/tap/opslevel-mcp'
@@ -61,10 +74,10 @@ packages:
       - 'font-ubuntu-mono-nerd-font'
       - 'ghostty'
       - 'raycast'
-      # Todo: Replace JDK versions with sdkman
-      - 'temurin@11'
-      - 'temurin@17'
-      - 'temurin@21'
+      # JDKs now managed via SDKMAN (see packages.sdkman section)
+      # - 'temurin@11'  # Moved to sdkman
+      # - 'temurin@17'  # Moved to sdkman
+      # - 'temurin@21'  # Moved to sdkman
 
 
 

--- a/run_onchange_after_install-sdkman-sdks.sh.tmpl
+++ b/run_onchange_after_install-sdkman-sdks.sh.tmpl
@@ -1,0 +1,110 @@
+{{- if .packages.custom_install.sdkman.enabled -}}
+#!/usr/bin/env bash
+# SDKMAN SDK installer
+# Installs and manages SDKs defined in .chezmoidata/packages.yaml
+# Runs after SDKMAN is installed
+
+set -e
+
+"$CHEZMOI_SOURCE_DIR/bin/figprint" "Installing SDKMAN SDKs..."
+
+SDKMAN_DIR="${SDKMAN_DIR:-$HOME/.sdkman}"
+SDKMAN_INIT="$SDKMAN_DIR/bin/sdkman-init.sh"
+
+if [[ ! -s "$SDKMAN_INIT" ]]; then
+    echo "Error: SDKMAN is not installed. Please run the SDKMAN installer first."
+    exit 1
+fi
+
+# Source SDKMAN to make sdk command available
+export SDKMAN_DIR
+source "$SDKMAN_INIT"
+
+# Disable interactive prompts for SDKMAN
+export SDKMAN_NON_INTERACTIVE=true
+
+install_sdk() {
+    local candidate="$1"
+    local version="$2"
+    
+    if [[ -z "$version" ]]; then
+        echo "Installing $candidate (latest)..."
+        if sdk install "$candidate" <<< "n" 2>/dev/null || sdk install "$candidate"; then
+            echo "✓ $candidate installed successfully"
+        else
+            echo "⚠ $candidate may already be installed or installation failed"
+        fi
+    else
+        echo "Installing $candidate $version..."
+        if sdk install "$candidate" "$version" <<< "n" 2>/dev/null || sdk install "$candidate" "$version"; then
+            echo "✓ $candidate $version installed successfully"
+        else
+            echo "⚠ $candidate $version may already be installed or installation failed"
+        fi
+    fi
+}
+
+set_default_sdk() {
+    local candidate="$1"
+    local version="$2"
+    
+    if [[ -n "$version" ]]; then
+        echo "Setting $candidate $version as default..."
+        sdk default "$candidate" "$version" 2>/dev/null || true
+    fi
+}
+
+echo "Installing Java SDKs..."
+{{- range $version := .packages.sdkman.java }}
+install_sdk "java" "{{ $version }}"
+{{- end }}
+
+# Set the first Java version as default
+{{- if .packages.sdkman.java }}
+{{- $firstJava := index .packages.sdkman.java 0 }}
+set_default_sdk "java" "{{ $firstJava }}"
+{{- end }}
+
+echo ""
+echo "Installing Maven..."
+{{- range $version := .packages.sdkman.maven }}
+install_sdk "maven" "{{ $version }}"
+{{- end }}
+
+# Set the first Maven version as default
+{{- if .packages.sdkman.maven }}
+{{- $firstMaven := index .packages.sdkman.maven 0 }}
+set_default_sdk "maven" "{{ $firstMaven }}"
+{{- end }}
+
+echo ""
+echo "Installing Spring Boot CLI..."
+{{- range $version := .packages.sdkman.springboot }}
+install_sdk "springboot" "{{ $version }}"
+{{- end }}
+
+# Set the first Spring Boot version as default
+{{- if .packages.sdkman.springboot }}
+{{- $firstSpringboot := index .packages.sdkman.springboot 0 }}
+set_default_sdk "springboot" "{{ $firstSpringboot }}"
+{{- end }}
+
+echo ""
+echo "=========================================="
+echo "SDKMAN SDK installation complete!"
+echo "=========================================="
+echo ""
+echo "Installed SDKs:"
+sdk current
+
+echo ""
+echo "To switch between versions, use:"
+echo "  sdk use java <version>"
+echo "  sdk use maven <version>"
+echo "  sdk use springboot <version>"
+echo ""
+echo "To list available versions:"
+echo "  sdk list java"
+echo "  sdk list maven"
+echo "  sdk list springboot"
+{{- end -}}

--- a/run_onchange_before_install-sdkman.sh.tmpl
+++ b/run_onchange_before_install-sdkman.sh.tmpl
@@ -1,0 +1,54 @@
+{{- if .packages.custom_install.sdkman.enabled -}}
+#!/usr/bin/env bash
+# Cross-platform SDKMAN installer
+# This script installs SDKMAN if not already present
+# Runs before package installation to ensure SDKMAN is available
+
+set -e
+
+"$CHEZMOI_SOURCE_DIR/bin/figprint" "Setting up SDKMAN..."
+
+SDKMAN_DIR="${SDKMAN_DIR:-$HOME/.sdkman}"
+SDKMAN_INIT="$SDKMAN_DIR/bin/sdkman-init.sh"
+
+if [[ -s "$SDKMAN_INIT" ]]; then
+    echo "SDKMAN is already installed at $SDKMAN_DIR"
+    echo "Checking for SDKMAN updates..."
+    
+    # Source SDKMAN to make sdk command available
+    export SDKMAN_DIR
+    source "$SDKMAN_INIT"
+    
+    # Self-update SDKMAN
+    sdk selfupdate force || echo "SDKMAN self-update skipped or failed (non-fatal)"
+else
+    echo "Installing SDKMAN..."
+    
+    # Check for required dependencies
+    if ! command -v curl &> /dev/null && ! command -v wget &> /dev/null; then
+        echo "Error: curl or wget is required to install SDKMAN"
+        exit 1
+    fi
+    
+    if ! command -v zip &> /dev/null || ! command -v unzip &> /dev/null; then
+        echo "Warning: zip/unzip recommended for SDKMAN"
+        # Try to install on common platforms
+        if command -v apt-get &> /dev/null; then
+            echo "Installing zip/unzip via apt..."
+            sudo apt-get update && sudo apt-get install -y zip unzip
+        elif command -v brew &> /dev/null; then
+            echo "Installing zip/unzip via brew..."
+            brew install zip unzip
+        fi
+    fi
+    
+    # Install SDKMAN using the official installer
+    # The installer is interactive by default, we make it non-interactive
+    export SDKMAN_DIR
+    curl -s "{{ .packages.custom_install.sdkman.install_url }}" | bash
+    
+    echo "SDKMAN installed successfully!"
+fi
+
+echo "SDKMAN setup complete."
+{{- end -}}

--- a/todo.md
+++ b/todo.md
@@ -25,7 +25,7 @@
 
 ## Mac Support:
 
-- [ ] Migrate to sdkman to manage Jvm
+- [x] Migrate to sdkman to manage Jvm (Completed - see run_onchange_*_install-sdkman*.sh.tmpl scripts)
 - [ ] Add Podman (UI & CLI)
 - [ ] Add Lando (Requires a custom install script)
 - [ ] Add tpm (Tmux package manager, requires custom install script)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR migrates JVM dependency management from Homebrew to SDKMAN, providing better cross-platform support and more flexible version management.

## Changes

### New Files
- **`run_onchange_before_install-sdkman.sh.tmpl`** - Cross-platform SDKMAN installer script
  - Checks if SDKMAN is already installed
  - Auto-updates SDKMAN if present  
  - Installs required dependencies (zip/unzip) if missing
  - Works on both macOS and Linux

- **`run_onchange_after_install-sdkman-sdks.sh.tmpl`** - SDK installer script
  - Installs Java, Maven, and SpringBoot SDKs from configuration
  - Sets the first version of each candidate as default
  - Provides helpful usage instructions after installation

### Modified Files
- **`.chezmoidata/packages.yaml`**
  - Added `custom_install.sdkman` configuration section for SDKMAN installation settings
  - Restructured `sdkman` section to support multiple versions per SDK candidate
  - Removed brew-managed JDKs (`temurin@11`, `temurin@17`, `temurin@21`)
  - Removed brew `maven` (now managed via SDKMAN)
  - Added comments explaining the migration

- **`todo.md`**
  - Marked SDKMAN migration task as complete

## Configuration

The new SDKMAN configuration in `packages.yaml`:

```yaml
packages:
  custom_install:
    sdkman:
      enabled: true
      install_url: "https://get.sdkman.io"

  sdkman:
    java:
      - "21.0.3-tem"    # Temurin 21 (LTS) - primary
      - "17.0.11-tem"   # Temurin 17 (LTS) 
      - "11.0.23-tem"   # Temurin 11 (LTS)
    maven:
      - "3.9.6"         # Latest stable Maven
    springboot:
      - "3.2.5"         # Spring Boot CLI
```

## How It Works

1. The `run_onchange_before_*` script runs first to install SDKMAN itself
2. The `run_onchange_after_*` script runs after to install the configured SDKs
3. The first version listed for each SDK candidate is set as the default

## Usage After Installation

```bash
# Switch between Java versions
sdk use java 17.0.11-tem

# List available versions
sdk list java

# Install additional versions
sdk install java 8.0.402-tem
```

## Deliverables Completed

- [x] New custom-install section for dependency management chezmoi scripts
- [x] Add custom install for SDKman cross-platform
- [x] Remove brew JDKs, maven and other java related utils that can instead be managed with SDKman
- [x] Add a new SDKMan dependency management section for describing required SDKs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c1f29fd-221d-4b1b-b6da-7d353c0aa28d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c1f29fd-221d-4b1b-b6da-7d353c0aa28d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

