### PR TITLE
Add Ollama dependency install script

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -6,6 +6,10 @@ packages:
       enabled: true
       # SDKMAN installation URL - cross-platform installer
       install_url: "https://get.sdkman.io"
+    ollama:
+      enabled: true
+      # Ollama official Linux installer
+      install_url: "https://ollama.com/install.sh"
 
   # SDKman managed SDKs - format: "candidate" or "candidate@version"
   # Use "sdk list <candidate>" to see available versions
@@ -34,6 +38,7 @@ packages:
       - 'tmux'
       - 'fzf'
       - 'zoxide'
+      - 'curl'
       - 'wget'
       - 'neovim'
       # JVM tools now managed via SDKMAN (see packages.sdkman section)
@@ -73,6 +78,7 @@ packages:
     casks:
       - 'font-ubuntu-mono-nerd-font'
       - 'ghostty'
+      - 'ollama'
       - 'raycast'
       # JDKs now managed via SDKMAN (see packages.sdkman section)
       # - 'temurin@11'  # Moved to sdkman

--- a/run_onchange_before_install-ollama.sh.tmpl
+++ b/run_onchange_before_install-ollama.sh.tmpl
@@ -1,0 +1,29 @@
+{{- if and (eq .chezmoi.os "linux") .packages.custom_install.ollama.enabled -}}
+#!/usr/bin/env bash
+# Installs Ollama on Linux using the official installer.
+
+set -e
+
+"$CHEZMOI_SOURCE_DIR/bin/figprint" "Setting up Ollama..."
+
+if command -v ollama &> /dev/null; then
+    echo "Ollama is already installed:"
+    ollama --version || true
+    exit 0
+fi
+
+if ! command -v curl &> /dev/null; then
+    if command -v apt-get &> /dev/null; then
+        echo "Installing curl via apt..."
+        sudo apt-get update && sudo apt-get install -y curl
+    else
+        echo "Error: curl is required to install Ollama"
+        exit 1
+    fi
+fi
+
+echo "Installing Ollama..."
+curl -fsSL "{{ .packages.custom_install.ollama.install_url }}" | sh
+
+echo "Ollama setup complete."
+{{- end -}}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add Ollama custom install configuration using the official installer URL
- add a Linux run_onchange hook that installs Ollama via `curl -fsSL https://ollama.com/install.sh | sh`
- add Ollama to macOS Homebrew casks and ensure curl is available for Linux installs

## Validation
- `bash -n /tmp/ollama-rendered.sh`
- YAML validation script confirming Ollama config, cask entry, and curl apt dependency
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbbaa898-7670-4f28-8e3d-4ef437473d61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbbaa898-7670-4f28-8e3d-4ef437473d61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

